### PR TITLE
Dev merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,20 +57,19 @@ Config will be searched in folowing paths:
 
 Core functionality is:
 
-- *fetch_module* - which makes available to fetch module from git repository and
-                   install it in this installation.
-                   Also it may automatically fetch dependencise of module been fetched,
-                   if it have *odoo_requirements.txt* file inside.
-- *fetch_requirements* - which can process *odoo_requirements.txt* files
+- *fetch* - which makes available to fetch module from git repository and
+            install it in this installation.
+            Also it may automatically fetch dependencise of module been fetched,
+            if it have *odoo_requirements.txt* file inside.
 - *generate_requirements* - Generates *odoo_requirements.txt* file, with list of modules
                             installed from git repositories. It checks all modules placed in
                             addons directory, which is passed as argument to this command or
                             got from odoo-helper.conf. Resulting file is suitable for *fetch_requirements command
-- *run_server* - Just runs current odoo install. all arguments passed directly to *openerp-server* executable
-- *test_module* - Test set of modules (```-m <module>``` option, which could be passed multiple times)
-                  Depending on options, may create new clean test daatabase.
-                  For depatis run this command with --help option$A
-- *link_module* - link specified module directory to current addons dir. mostly used internaly
+- *server* - Contorlls odoo server of current project. run with *--help* option for more info.
+- *test* - Test set of modules (```-m <module>``` option, which could be passed multiple times)
+           Depending on options, may create new clean test daatabase.
+           For depatis run this command with --help option$A
+- *link* - link specified module directory to current addons dir. mostly used internaly
 - *create_db* - allows to create database from command line
 - *drop_db* - allows to drop database from commandline
 - *list_db* - lists databases, available for this odoo instance
@@ -82,7 +81,7 @@ For details use *--help* option
 *odoo_requirements.txt* parsed line by line, and each line must be just set of options to ```odoo-helper fetch_module``` command:
 
 ```
--r|--repo <git repository> [-m|--module <odoo module name>] [-n|--name <repo name>] [-b|--branch <git branch>]
+-r|--repo <git repository>  [-b|--branch <git branch>] [-m|--module <odoo module name>] [-n|--name <repo name>]
 --requirements <requirements file>
 -p|--python <python module>
 
@@ -106,18 +105,28 @@ For details run ```odoo-helper fetch_module --help```
 ## Complete example
 
 ```bash
-odoo-install --install-dir odoo-7.0 --branch 7.0
+odoo-install --install-dir odoo-7.0 --branch 7.0 --extra-utils
 cd odoo-7.0
 
 # Now You will have odoo-7.0 installed in this directory.
 # Note, thant Odoo this odoo install uses virtual env (venv dir)
 # Also You will find there odoo-helper.conf config file
 
-# So now You may run local odoo server:
-odoo-helper run_server   # This will automaticaly use config file: conf/odoo.conf
+# So now You may run local odoo server (i.e openerp-server script).
+# Note that this command run's server in foreground.
+odoo-helper server   # This will automaticaly use config file: conf/odoo.conf
+
+# Also you may run server in background using
+odoo-helper server start
+
+# there are also few additional server related commands:
+odoo-helper server status
+odoo-helper server log
+odoo-helper server restart
+odoo-helper server stop
 
 # Let's install base_tags addon into this odoo installation
-odoo-helper fetch --github katyukha/base_tags
+odoo-helper fetch --github katyukha/base_tags --branch master
 
 # Now look at custom_addons/ dir, there will be placed links to addons
 # from https://github.com/katyukha/base_tags repository
@@ -134,4 +143,32 @@ odoo-helper test --create-test-db -m base_tags -m product_tags
 # If You need color output from Odoo, you may use '--use-unbuffer' option,
 # but it depends on 'expect-dev' package
 odoo-helper --use-unbuffer test --create-test-db -m base_tags -m product_tags
+
+# The one cool thing of odoo-helper script, you may not remeber paths to odoo instalation,
+# and if you change directory to another inside your odoo project, everything will continue to work.
+cd custom_addons
+odoo-helper server status
+dooo-helper server restart
+
+# ...
+
+# So... let's install one more odoo version
+# go back to directory containing our projects (that one, where odoo-7.0 project is placed)
+cd ../../
+
+# Let's install odoo of version 8.0 too here.
+odoo-install --install-dir odoo-8.0 --branch 8.0 --extra-utils
+cd odoo-8.0
+
+# and install there for example addon 'project_sla' for 'project-service' Odoo Comutinty repository
+# Note  that odoo-helper script will automaticaly fetch branch named as server version in current install,
+# if another branch was not specified
+odoo-helper fetch --oca project-service -m project_sla
+
+# and run tests for it
+odoo-helper test --create-test-db -m project_sla
+
+
+# also if you want to install python packages in current installation environment, you may use command:
+odoo-helper fetch -p suds  # this installs 'suds' python package
 ```

--- a/bin/odoo-helper
+++ b/bin/odoo-helper
@@ -29,6 +29,14 @@ function execu {
         source $VENV_DIR/bin/activate;
     fi
 
+    # Check unbuffer option
+    if [ ! -z $USE_UNBUFFER ] && ! command -v unbuffer >/dev/null 2>&1; then
+        echo -e "${REDC}Command 'unbuffer' not found. Install it to use --use-unbuffer option";
+        echo -e "It could be installed by installing package expect-dev";
+        echo -e "Using standard behavior${NC}";
+        USE_UNBUFFER=;
+    fi
+
     if [ -z $USE_UNBUFFER ]; then
         eval "$@";
         local res=$?;
@@ -132,20 +140,17 @@ function print_usage {
         ${PROJECT_ROOT_DIR:-'No project found'};
 
     Available commands:
-        fetch | fetch_module [--help]
-        link | link_module <repo_path> [<module_name>]
-        fetch_requirements <file name>
+        fetch [--help]
+        link <repo_path> [<module_name>]
         generate_requirements [addons dir]
-        run | run_server [args passed to server]
-        start_server [args passed to server]
-        stop_server [args passed to server]
-        restart_server [args passed to server]
-        test | test_module [--help]
+        server [--help]
+        odoo-py [args]                              - run project-specific odoo.py script
+        test [--help]
         env                                         - export environment variables
         create_db <db_name> [cofig file to use]
         drop_db <db_name> [cofig file to use]
         list_db [config file to use]
-        help
+        help | --help | -h
     
     Global options:
         --addons-dir <addons_directory>
@@ -158,7 +163,8 @@ function print_usage {
                                                 otherwise standard 'exec' will be used to run odoo server
                                                 this helps to make odoo server think that it runs in terminal thus
                                                 it provides colored output.
-        --verbose                             - show extra output
+        --use-test-conf                       - Use test configuration file for commands
+        --verbose|--vv                        - show extra output
 
     Also global options may be set up using configuration files.
     Folowing file paths will be searched for file $CONF_FILE_NAME:
@@ -299,7 +305,8 @@ function fetch_python_dep {
     fi
 }
 
-# fetch_module -r|--repo <git repository> [-m|--module <odoo module name>] [-n|--name <repo name>] [-b|--branch <git branch>] [--requirements <requirements file>]
+# fetch_module -r|--repo <git repository> [-m|--module <odoo module name>] [-n|--name <repo name>] [-b|--branch <git branch>]
+# fetch_module --requirements <requirements file>
 # fetch_module -p <python module> [-p <python module>] ...
 function fetch_module {
     # TODO: simplify this function. remove unneccessary options
@@ -367,7 +374,7 @@ function fetch_module {
             ;;
             --oca)
                 REPOSITORY="https://github.com/OCA/$2";
-                REPO_BRANCH=$ODOO_BRANCH;  # Here we could use same branch as branch of odoo installed
+                REPO_BRANCH=${REPO_BRANCH:-$ODOO_BRANCH};  # Here we could use same branch as branch of odoo installed
                 shift;
             ;;
             -m|--module)
@@ -387,7 +394,7 @@ function fetch_module {
                 fetch_python_dep $2
                 shift;
             ;;
-            -h|--help)
+            -h|--help|help)
                 echo "$usage";
                 exit 0;
             ;;
@@ -469,8 +476,11 @@ function fetch_module {
 function get_server_script {
     echo "openerp-server";
     #case $ODOO_BRANCH in
-        #8.0|7.0|6.0)
+        #7.0|6.1|6.0)
             #echo "openerp-server";
+        #;;
+        #8.0|9.0|master)
+            #echo "odoo.py";
         #;;
         #*)
             #echo "unknown server version";
@@ -483,22 +493,33 @@ function get_server_script {
 function run_server_impl {
     local SERVER=`get_server_script`;
     echo -e "${LBLUEC}Running server${NC}: $SERVER $@";
+    export OPENERP_SERVER=$ODOO_CONF_FILE;
     execu $SERVER "$@";
+    unset OPENERP_SERVER;
 }
 
-# run_server <arg1> .. <argN>
+# server_run <arg1> .. <argN>
 # all arguments will be passed to odoo server
-function run_server {
-    run_server_impl -c $ODOO_CONF_FILE "$@";
+function server_run {
+    run_server_impl "$@";
 }
 
-function start_server {
-    run_server --pidfile=$ODOO_PID_FILE "$@" &
+function server_start {
+    # Check if server process is already running
+    if [ -f "$ODOO_PID_FILE" ]; then
+        local pid=`cat $ODOO_PID_FILE`;
+        if kill -0 $pid >/dev/null 2>&1; then
+            echo -e "${REDC}Server process already running. PID=${pid}.${NC}";
+            exit 1;
+        fi
+    fi
+
+    run_server_impl --pidfile=$ODOO_PID_FILE "$@" &
     sleep 2;
     echo "Odoo started using PID File $ODOO_PID_FILE. Process ID: $!";
 }
 
-function stop_server {
+function server_stop {
     if [ -f "$ODOO_PID_FILE" ]; then
         local pid=`cat $ODOO_PID_FILE`;
         if kill $pid; then
@@ -511,11 +532,110 @@ function stop_server {
     fi
 }
 
-function restart_server {
-    stop_server;
-    start_server "$@";
+function server_status {
+    if [ -f "$ODOO_PID_FILE" ]; then
+        local pid=`cat $ODOO_PID_FILE`;
+        if kill -0 $pid >/dev/null 2>&1; then
+            echo -e "${GREENC}Server process already running. PID=${pid}.${NC}";
+        else
+            echo -e "${YELLOWC}Pid file points to unexistent process.${NC}";
+        fi
+    else
+        echo "Server stopped";
+    fi
 }
 
+# server [options] <command> <args>
+# server [options] start <args>
+# server [options] stop <args>
+function server {
+    local usage="
+    Usage 
+
+        $SCRIPT_NAME server [options] [command] [args]
+
+    args - arguments that usualy will be passed forward to openerp-server script
+
+    Commands:
+        run             - run the server. if no command supply, this one will be used
+        start           - start server in background
+        stop            - stop background running server
+        restart         - restart background server
+        status          - status of background server
+        log             - open server log
+        -h|--help|help  - display this message
+
+    Options:
+        --use-test-conf     - Use test configuration file for server
+    ";
+
+    ## Parse command line options and run commands
+    #if [[ $# -lt 1 ]]; then
+        #echo "No commands supplied $#: $@";
+        #echo "$usage";
+        #exit 0;
+    #fi
+
+    while [[ $# -gt 0 ]]
+    do
+        key="$1";
+        case $key in
+            -h|--help|help)
+                echo "$usage";
+                exit 0;
+            ;;
+            --use-test-conf)
+                echo "Not implemented option --user-test-conf!";
+            ;;
+            run)
+                shift;
+                server_run "$@";
+                exit;
+            ;;
+            start)
+                shift;
+                server_start "$@";
+                exit;
+            ;;
+            stop)
+                shift;
+                server_stop "$@";
+                exit;
+            ;;
+            restart)
+                shift;
+                server_stop;
+                server_start "$@";
+                exit;
+            ;;
+            status)
+                shift;
+                server_status "$@";
+                exit
+            ;;
+            log)
+                shift;
+                less $LOG_DIR/odoo.log;
+                exit;
+            ;;
+            *)
+                # all nex options have to be passed to the server
+                break;
+            ;;
+        esac;
+        shift;
+    done;
+    server_run "$@";
+    exit;
+}
+
+# odoo_py <args>
+function odoo_py {
+    echov -e "${LBLUEC}Running odoo.py with arguments${NC}:  $@";
+    export OPENERP_SERVER=$ODOO_CONF_FILE;
+    execu odoo.py "$@";
+    unset OPENERP_SERVER;
+}
 
 # odoo_create_db <name> [odoo_conf_file]
 function odoo_create_db {
@@ -524,37 +644,34 @@ function odoo_create_db {
 
     echov "Creating odoo database $db_name using conf file $conf_file";
 
-    local python_cmd="import openerp;";
-    python_cmd="$python_cmd openerp.tools.config.parse_config(['-c', '$conf_file']);";
-    python_cmd="$python_cmd openerp.service.start_internal();"
-    python_cmd="$python_cmd openerp.cli.server.setup_signal_handlers();"
-    python_cmd="$python_cmd openerp.netsvc.dispatch_rpc('db', 'create_database', (openerp.tools.config['admin_passwd'], '$db_name', True, 'en_US'));"
+    local python_cmd="import erppeek; cl=erppeek.Client(['-c', '$conf_file']);";
+    python_cmd="$python_cmd cl.db.create_database(cl._server.tools.config['admin_passwd'], '$db_name', True, 'en_US');"
 
     execu python -c "\"$python_cmd\"";
+    
+    echo -e "${GREENC}Database $db_name created successfuly!${NC}";
 }
 
 # odoo_drop_db <name> [odoo_conf_file]
 function odoo_drop_db {
     local db_name=$1;
     local conf_file=${2:-$ODOO_CONF_FILE};
-    local python_cmd="import openerp;";
-    python_cmd="$python_cmd openerp.tools.config.parse_config(['-c', '$conf_file']);";
-    python_cmd="$python_cmd openerp.service.start_internal();"
-    python_cmd="$python_cmd openerp.cli.server.setup_signal_handlers();"
-    python_cmd="$python_cmd openerp.netsvc.dispatch_rpc('db', 'drop', (openerp.tools.config['admin_passwd'], '$db_name'));"
 
+    local python_cmd="import erppeek; cl=erppeek.Client(['-c', '$conf_file']);";
+    python_cmd="$python_cmd cl.db.drop(cl._server.tools.config['admin_passwd'], '$db_name');"
+    
     execu python -c "\"$python_cmd\"";
+    
+    echo -e "${GREENC}Database $db_name dropt successfuly!${NC}";
 }
 
 # odoo_list_db [odoo_conf_file]
 function odoo_list_db {
     local conf_file=${2:-$ODOO_CONF_FILE};
-    local python_cmd="import openerp;";
-    python_cmd="$python_cmd openerp.tools.config.parse_config(['-c', '$conf_file']);";
-    python_cmd="$python_cmd openerp.service.start_internal();"
-    python_cmd="$python_cmd openerp.cli.server.setup_signal_handlers();"
-    python_cmd="$python_cmd print '\n'.join(['%s'%d for d in openerp.netsvc.dispatch_rpc('db', 'list', tuple())]);"
 
+    local python_cmd="import erppeek; cl=erppeek.Client(['-c', '$conf_file']);";
+    python_cmd="$python_cmd print '\n'.join(['%s'%d for d in cl.db.list()]);";
+    
     execu python -c "\"$python_cmd\"";
 }
 
@@ -605,7 +722,7 @@ function test_module_impl {
         --no-xmlrpc --no-xmlrpcs "$@";
     # Test module
     run_server_impl -c $ODOO_TEST_CONF_FILE --update=$module --log-level=test --test-enable --stop-after-init \
-        --no-xmlrpc --no-xmlrpcs "$@";
+        --no-xmlrpc --no-xmlrpcs --workers=0 "$@";
     set -e; # Fail on any error
 }
 
@@ -852,21 +969,17 @@ do
         --use-unbuffer)
             USE_UNBUFFER=1;
         ;;
-        --verbose)
+        --verbose|-vv)
             VERBOSE=1;
         ;;
         env)
             do_export_vars;
             exit;
         ;;
-        fetch|fetch_module)
+        fetch)
             shift;
             fetch_module "$@";
             exit
-        ;;
-        fetch_requirements)
-            fetch_requirements $2;
-            exit;
         ;;
         generate_requirements)
             shift;
@@ -878,27 +991,17 @@ do
             link_module "$@"
             exit;
         ;;
-        run|run_server)
+        server)
             shift;
-            run_server "$@";
+            server "$@";
             exit;
         ;;
-        start_server)
+        odoo-py)
             shift;
-            start_server "$@";
+            odoo_py "$@";
             exit;
         ;;
-        stop_server)
-            shift;
-            stop_server "$@";
-            exit;
-        ;;
-        restart_server)
-            shift;
-            restart_server "$@";
-            exit;
-        ;;
-        test|test_module)
+        test)
             shift;
             test_module "$@";
             exit;

--- a/bin/odoo-helper
+++ b/bin/odoo-helper
@@ -163,7 +163,6 @@ function print_usage {
                                                 otherwise standard 'exec' will be used to run odoo server
                                                 this helps to make odoo server think that it runs in terminal thus
                                                 it provides colored output.
-        --use-test-conf                       - Use test configuration file for commands
         --verbose|--vv                        - show extra output
 
     Also global options may be set up using configuration files.
@@ -585,7 +584,8 @@ function server {
                 exit 0;
             ;;
             --use-test-conf)
-                echo "Not implemented option --user-test-conf!";
+                ODOO_CONF_FILE=$ODOO_TEST_CONF_FILE;
+                echo -e "${YELLOWC}NOTE${NC}: Using test configuration file: $ODOO_TEST_CONF_FILE";
             ;;
             run)
                 shift;

--- a/bin/odoo-install
+++ b/bin/odoo-install
@@ -55,6 +55,9 @@ function print_usage {
     Available options:
          --install-dir <dir>         - directory to install odoo in. default: $INSTALL_DIR
          --branch <branch>           - specify odoo branch to clone. default: $BRANCH
+         --extra-utils               - install extra python packages. (for example 'erppeek', which
+                                       is used by odoo-helper script to manage databases)
+         --use-system-packages       - allow virtualenv use system packages. (default: disabled)
          --download-archive on|off   - if on, then odoo will be downloaded as archive. it is faster
                                        Default: $DOWNLOAD_ARCHIVE
          --use-shallow-clone on|off  - if not set 'download-archive' then, this option may increase
@@ -96,6 +99,12 @@ function parse_options {
             --branch|-b)
                 BRANCH=$2;
                 shift;
+            ;;
+            --extra-utils)
+                INSTALL_EXTRA_UTILS=1;
+            ;;
+            --use-system-packages)
+                USE_SYSTEM_SITE_PACKAGES=1;
             ;;
             --download-archive)
                 DOWNLOAD_ARCHIVE=$2;
@@ -183,16 +192,26 @@ function install_odoo {
 
     # install into virtualenv odoo and its dependencies
     if [ ! -d $VENV_DIR ]; then
-        virtualenv --system-site-packages $VENV_DIR;
+        if [ ! -z $USE_SYSTEM_SITE_PACKAGES ]; then
+            local venv_opts=" --system-site-packages ";
+        else
+            local venv_opts="";
+        fi
+        virtualenv $venv_opts $VENV_DIR;
     fi
     source $VENV_DIR/bin/activate;
     pip install --upgrade pip setuptools;  # required to make odoo.py work correctly
+
     if ! python -c "import pychart"; then
         pip install http://download.gna.org/pychart/PyChart-1.39.tar.gz;
     fi
-    pip install --allow-external=PIL \
-                --allow-unverified=PIL \
-                -e $ODOO_PATH;
+
+    if [ ! -z $INSTALL_EXTRA_UTILS ]; then
+        pip install --upgrade erppeek;
+    fi
+
+    pip install --upgrade --allow-external=PIL --allow-unverified=PIL PIL
+    pip install -e $ODOO_PATH;
     deactivate;
 }
 
@@ -466,5 +485,5 @@ chmod a+x $BIN_DIR/new_module.bash;
 
 #---------------------------------------------
 
-echo "Edit configuration at $ODOO_CONF_FILE.conf";
+echo "Edit configuration at $ODOO_CONF_FILE";
 echo "To create skeleton for new module use $BIN_DIR/new_module.bash script";


### PR DESCRIPTION
odoo-helper: added / modified commands.
ERPPeek used to create/drop/list databases


    odoo-helper modifications:
        Added commands:
            odoo-helper server
            odoo-helper server run
            odoo-helper server start
            odoo-helper server stop
            odoo-helper server restart
            odoo-helper server status
            odoo-helper server log
            odoo-helper odoo-py

        Modified commands:
            odoo-helper fetch
            odoo-helper test

        Removed commands:
            odoo-helper test_module        (replaced by single 'test' command)
            odoo-helper start_server       (replaced by 'server start')
            odoo-helper stop_server        (replaced by 'server stop')
            odoo-helper restart_server     (replaced by 'server restart')
            odoo-helper run_server         (replaced by 'server run')
            odoo-helper run                (replaced by 'server run')
            odoo-helper fetch_module       (replaced by single 'fetch' command)
            odoo-helper fetch_requirements (just use 'fetch --requirements')

    odoo-install modifications:
        Added options:
            odoo-install --extra-utils
            odoo-install --use-system-packages