### PR TITLE
Release 0.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 *.swp
 *.swn
 *.swo
+*.swm
 /coverage/
 /venv/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+#dist: trusty
 language: bash
 
 cache:
@@ -13,7 +13,6 @@ env:
 
 install:
   - "sudo apt-get install -y -qq python-all-dev"
-  - "sudo pip install gevent"
 
   - "rvm use 2.3"
   - "gem install bashcov coveralls"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: required
+dist: trusty
 language: bash
 
 env:
@@ -7,8 +8,9 @@ env:
     - ODOO_HELPER_ROOT=$TRAVIS_BUILD_DIR
 
 install:
-  #- "sudo apt-get update -y -qq"
-  #- "sudo apt-get install -y -qq python-gevent"
+  - "sudo apt-get update -y -qq"
+  - "sudo apt-get install -y -qq python-gevent"
+  - "sudo apt-get install python-all-dev"
   - "sudo pip install gevent"
 
   - "rvm use 2.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,21 @@ sudo: required
 dist: trusty
 language: bash
 
+cache:
+    pip: true
+    apt: true
+
 env:
   global:
     - CI_RUN=1
     - ODOO_HELPER_ROOT=$TRAVIS_BUILD_DIR
 
 install:
-  - "sudo apt-get update -y -qq"
-  - "sudo apt-get install -y -qq python-gevent"
-  - "sudo apt-get install python-all-dev"
+  - "sudo apt-get install -y -qq python-all-dev"
   - "sudo pip install gevent"
 
   - "rvm use 2.3"
-  - "gem install bashcov"
-  - "gem install coveralls"
+  - "gem install bashcov coveralls"
   - "bash install-user.bash"
 
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,59 @@
 # Changelog
 
-## Version 0.0.11
+## Version 0.1.0
+
+- Added ``odoo-helper addons pull_updates`` command
+- Added basic support of Odoo 10
+- Added ``odoo-helper --version`` command
+- Refactored ``odoo-install`` script:
+  - Always install python extra utils
+  - Removed following options (primery goal of this, is to simplify ``odoo-install`` script):
+    - ``--extra-utils``: extrautils are installed by default
+    - ``--install-sys-deps``: use instead separate command: ``odoo-helper install``
+    - ``--install-and-conf-postgres``: use instead separate command: ``odoo-helper install`` or ``odoo-helper postgres``
+    - ``--use-system-packages``: seems to be not useful
+    - ``--use-shallow-clone``: seems to be not useful
+    - ``--use-unbuffer``: seems to be not useful
+  - Added following options:
+    - ``--odoo-version``: this option is useful in case of using custom
+      repository and custom branch with name different then odoo's version branches
+  - Fixed bug with ``--conf-opt-*`` and ``--test-conf-opt-*`` options
+- Completely refactored ``odoo-helper test`` command
+  - removed ``--reinit-base``
+  - added ``--coverage`` options
+  - Added subcommand ``odoo-helper test flake8``
+  - Added subcommand ``odoo-helper test pylint``
+- ``odoo-helper addons update-list`` command: ran for all databases if no db specified
+- suppress git feedback in ``odoo-helper system update``
+- improve system-wide install script: allow to choose odoo-helper branch or
+  commit to install
+- Added ability to run tests for directory.
+  In this case odoo-helper script will automaticaly discover addons in
+  that directory
+- odoo-helper: added ``--no-colors`` option
+- ``odoo-helper tr`` command improved:
+  - ``import`` and ``load`` subcommands can be ran on all databases
+  - ``import`` subcommand: added ability to search addons in directory
+  - bugfix in ``tr import``: import translations only for installed addons
+- Added ``addons test-installed`` command
+  This allows to find databases where this addon is installed
+- Bugfix: ``addons check_updates`` command: show repositories that caused errors when checking for updates
+- ``addons status`` command now shows repository's remores
+- ``odoo-helper fetch`` and ``odoo-helper link`` commands refactored:
+  - Added recursion protection for both of therm, to avoid infinite recursion
+  - ``odoo-helepr fetch`` filter-out uninstallable addons, on linking muti-addon repo
+  - ``odoo-helper link`` now is recursive, thus it will look for odoo addons
+    recursively in a specified directory and link them all.
+- Added ``odoo-helper install`` command, which allows to install
+  system dependencies for specific odoo version without installing odoo itself
+- Added ``odoo-helper addons install --no-restart`` option
+- Added ``odoo-helper addons update --no-restart`` option
+- Added following shortcuts:
+  - ``odoo-helper pip`` to run pip for current project
+  - ``odoo-helper start`` for ``odoo-helper server start``
+  - ``odoo-helper stop`` for ``odoo-helper server stop``
+  - ``odoo-helper restart`` for ``odoo-helper server restart``
+  - ``odoo-helper log`` for ``odoo-helper server log``
 
 
 ## Version 0.0.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 0.0.11
+
+
 ## Version 0.0.10
 
 - Bugfixes in ``odoo-helper test`` command

--- a/README.md
+++ b/README.md
@@ -143,18 +143,33 @@ For details run ```odoo-helper fetch --help```
 ## Complete example
 
 ```bash
-odoo-install --install-dir odoo-7.0 --branch 7.0 --extra-utils
+# Install odoo-helper scripts pre-requirements.
+# This step should be usualy ran one time, and is required to ensure that
+# all odoo-helper dependencies installed.
+odoo-helper install pre-requirements -y
+
+# Install system dependencies for odoo version 7.0
+# This option requires sudo.
+odoo-helper install sys-deps -y 7.0;
+
+# Install postgres and create there user with name='odoo' and password='odoo'
+odoo-helper install postgres odoo odoo
+
+# Install odoo 7.0 into 'odoo-7.0' directory
+odoo-install -i odoo-7.0 --odoo-version 7.0
 cd odoo-7.0
 
-# Now You will have odoo-7.0 installed in this directory.
-# Note, thant Odoo this odoo install uses virtual env (venv dir)
+# Now You have odoo-7.0 installed in this directory.
+# Note, that this odoo installation uses virtual env (venv dir)
 # Also You will find there odoo-helper.conf config file
 
 # So now You may run local odoo server (i.e openerp-server script).
 # Note that this command run's server in foreground.
-odoo-helper server   # This will automaticaly use config file: conf/odoo.conf
+odoo-helper server run  # This will automaticaly use config file: conf/odoo.conf
 
-# Also you may run server in background using
+# Press Ctrl+C to stop seerver
+
+# To run server in backgroud use following command
 odoo-helper server start
 
 # there are also few additional server related commands:
@@ -163,23 +178,29 @@ odoo-helper server log
 odoo-helper server restart
 odoo-helper server stop
 
+# Also there are shourtcuts for these commands:
+odoo-helper status
+odoo-helper log
+odoo-helper restart
+odoo-helper stop
+
 # Let's install base_tags addon into this odoo installation
 odoo-helper fetch --github katyukha/base_tags --branch master
 
 # Now look at custom_addons/ dir, there will be placed links to addons
 # from https://github.com/katyukha/base_tags repository
-# But repository itself is placed in downloads/ directory
+# But repository itself is placed in repositories/ directory
 # By default no branch specified when You fetch module,
 # but there are -b or --branch option which can be used to specify which branch to fetch
 
 # Now let's run tests for these just installed modules
 odoo-helper test --create-test-db -m base_tags -m product_tags
 
-# this will create test database (it will be dropt after test finishes) and 
+# this will create test database (it will be dropt after test finished) and 
 # run tests for modules 'base_tags' and 'product_tags'
 
 # If You need color output from Odoo, you may use '--use-unbuffer' option,
-# but it depends on 'expect-dev' package
+# but it depends on 'expect-dev' package.
 odoo-helper --use-unbuffer test --create-test-db -m base_tags -m product_tags
 
 # The one cool thing of odoo-helper script, you may not remeber paths to odoo instalation,
@@ -192,14 +213,18 @@ dooo-helper server restart
 # go back to directory containing our projects (that one, where odoo-7.0 project is placed)
 cd ../../
 
-# Let's install odoo of version 8.0 too here.
-odoo-install --install-dir odoo-8.0 --branch 8.0 --extra-utils
+# Let's install odoo of version 8.0 here too.
+# First, install system dependencies for odoo version 8.0
+odoo-helper install sys-deps -y 7.0;
+
+# And when system dependencies installed, install odoo itself
+odoo-install --install-dir odoo-8.0 --odoo-version 8.0
 cd odoo-8.0
 
-# and install there for example addon 'project_sla' for 'project-service' Odoo Comutinty repository
+# and install there for example addon 'project_sla' for 'project' Odoo Comutinty repository
 # Note  that odoo-helper script will automaticaly fetch branch named as server version in current install,
 # if another branch was not specified
-odoo-helper fetch --oca project-service -m project_sla
+odoo-helper fetch --oca project -m project_sla
 
 # and run tests for it
 odoo-helper test --create-test-db -m project_sla

--- a/README.md
+++ b/README.md
@@ -146,11 +146,11 @@ For details run ```odoo-helper fetch --help```
 # Install odoo-helper scripts pre-requirements.
 # This step should be usualy ran one time, and is required to ensure that
 # all odoo-helper dependencies installed.
-odoo-helper install pre-requirements -y
+odoo-helper install pre-requirements
 
 # Install system dependencies for odoo version 7.0
 # This option requires sudo.
-odoo-helper install sys-deps -y 7.0;
+odoo-helper install sys-deps 7.0;
 
 # Install postgres and create there user with name='odoo' and password='odoo'
 odoo-helper install postgres odoo odoo
@@ -215,7 +215,7 @@ cd ../../
 
 # Let's install odoo of version 8.0 here too.
 # First, install system dependencies for odoo version 8.0
-odoo-helper install sys-deps -y 7.0;
+odoo-helper install sys-deps 8.0;
 
 # And when system dependencies installed, install odoo itself
 odoo-install --install-dir odoo-8.0 --odoo-version 8.0

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ After instalation You will have ```odoo-helper-scripts``` directory under ```/op
 (also ```odoo-helper``` and ```odoo-install``` scripts will be linked to ```/usr/local/bin/``` dir).
 And ```/etc/odoo-helper.conf``` file will be generated with path to odoo-helper-scripts install dir.
 
+If you wish to install from *dev* branch, you can use following command:
+
+```bash
+wget -O - https://raw.githubusercontent.com/katyukha/odoo-helper-scripts/master/install-system.bash | sudo bash -s - dev
+```
+
 
 ## Features
 

--- a/bin/odoo-helper
+++ b/bin/odoo-helper
@@ -103,15 +103,6 @@ function print_usage {
                                           directories. First one found will be used
 
     Configuration files are simple bash scripts that sets environment variables
-
-    Available environment variables:
-        DOWNLOADS_DIR                   - Directory where all downloads hould be placed
-        ADDONS_DIR                      - directory to place addons fetched (thats one in odoo's addons_path)
-        VENV_DIR                        - Directory of virtual environment, if virtualenv is used
-                                          Note, that if VENV_DIR not set, than system will think that odoo is installed system-wide.
-        USE_COPY                        - If set, then addons will be coppied in addons dir, instead of standard symlinking
-        ODOO_BRANCH                     - used in run_server command to decide how to run it
-        ODOO_TEST_CONF_FILE             - used to run tests. this configuration file will be used for it
 ";
 }
 

--- a/bin/odoo-helper
+++ b/bin/odoo-helper
@@ -93,6 +93,7 @@ function print_usage {
                                                 otherwise standard 'exec' will be used to run odoo server
                                                 this helps to make odoo server think that it runs in terminal thus
                                                 it provides colored output.
+        --no-colors                           - disable colored output
         --verbose|--vv                        - show extra output
 
     Also global options may be set up using configuration files.
@@ -195,6 +196,9 @@ function odoo_helper_main {
             --use-unbuffer)
                 USE_UNBUFFER=1;
             ;;
+            --no-colors)
+                deny_colors;
+            ;;
             --verbose|-vv)
                 VERBOSE=1;
             ;;
@@ -296,7 +300,7 @@ function odoo_helper_main {
             exec)
                 shift;
                 load_project_conf;
-                execu "$@";
+                execv "$@";
                 exit 0;
             ;;
             *)

--- a/bin/odoo-helper
+++ b/bin/odoo-helper
@@ -79,6 +79,7 @@ function print_usage {
         system lib-path <lib name>               - print path to lib with specified name
                                                    this allows to use some libs of this project in external utils
         exec <cmd> [args]                        - exec command in project environment. Useful if virtualenv is used
+        pip <pip arguments>                      - shortcut for *odoo-helper exec pip*
         help | --help | -h                       - display this help message
         --version                                - display odoo-helper version and exit
     
@@ -301,6 +302,12 @@ function odoo_helper_main {
                 shift;
                 load_project_conf;
                 execv "$@";
+                exit 0;
+            ;;
+            pip)
+                shift;
+                load_project_conf;
+                execv pip "$@";
                 exit 0;
             ;;
             *)

--- a/bin/odoo-helper
+++ b/bin/odoo-helper
@@ -80,6 +80,7 @@ function print_usage {
                                                    this allows to use some libs of this project in external utils
         exec <cmd> [args]                        - exec command in project environment. Useful if virtualenv is used
         help | --help | -h                       - display this help message
+        --version                                - display odoo-helper version and exit
     
     Global options:
         --addons-dir <addons_directory>
@@ -179,6 +180,10 @@ function odoo_helper_main {
         case $key in
             -h|--help|help)
                 print_usage;
+                exit 0;
+            ;;
+            --version)
+                echo "$ODOO_HELPER_VERSION";
                 exit 0;
             ;;
             --downloads-dir)

--- a/bin/odoo-helper
+++ b/bin/odoo-helper
@@ -40,6 +40,7 @@ ohelper_require "git";
 ohelper_require "odoo";
 ohelper_require "tr";
 ohelper_require "postgres";
+ohelper_require "system";
 # ----------------------------------------------------------------------------------------
 
 function print_usage {
@@ -77,9 +78,8 @@ function print_usage {
         scaffold <addon_name> [addon_path]       - shortcut for odoo.py scaffold command.
         print_config                             - print current configuration
         status                                   - show project status
-        system update [branch]                   - update odoo-helper-scripts
-        system lib-path <lib name>               - print path to lib with specified name
-                                                   this allows to use some libs of this project in external utils
+        start|stop|restart|log                   - shortcuts for server commands
+        system [--help]                          - odoo-helper related functions
         exec <cmd> [args]                        - exec command in project environment. Useful if virtualenv is used
         pip <pip arguments>                      - shortcut for *odoo-helper exec pip*
         help | --help | -h                       - display this help message
@@ -126,36 +126,6 @@ function show_project_status {
         Odoo branch: ${ODOO_BRANCH:-'Not defined'}
         Server status: ${server_status}
     ";
-}
-
-# update odoo-helper-scripts
-function update_odoo_helper_scripts {
-    local scripts_branch=$1;
-
-    # update
-    local cdir=$(pwd);
-    cd $ODOO_HELPER_ROOT;
-    if [ -z $scripts_branch ]; then
-        git pull;
-    else
-        git fetch -q origin;
-        if ! git checkout -q origin/$scripts_branch; then
-            git checkout -q $scripts_branch;
-        fi
-    fi
-
-    # update odoo-helper bin links
-    local base_path=$(dirname $ODOO_HELPER_ROOT);
-    for oh_cmd in $ODOO_HELPER_BIN/*; do
-        if ! command -v $(basename $oh_cmd) >/dev/null 2>&1; then
-            if [ "$base_path" == /opt* ]; then
-                with_sudo ln -s $oh_cmd /usr/local/bin/;
-            elif [ "$base_path" == $HOME/* ]; then
-                ln -s $oh_cmd $HOME/bin;
-            fi
-        fi
-    done
-    cd $cdir;
 }
 
 # function that parses commandline arguments and executes commands
@@ -295,17 +265,15 @@ function odoo_helper_main {
                 exit;
             ;;
             system)
-                if [ "$2" == "update" ]; then
-                    shift;
-                    shift;
-                    update_odoo_helper_scripts "$@";
-                    exit 0;
-                elif [ "$2" == "lib-path" ]; then
-                    shift;
-                    shift;
-                    oh_get_lib_path "$@"
-                    exit 0;
-                fi
+                shift;
+                system_entry_point "$@";
+                exit;
+            ;;
+            # Server shortcuts
+            start|stop|restart|log)
+                load_project_conf;
+                server "$@";
+                exit;
             ;;
             exec)
                 shift;

--- a/bin/odoo-helper
+++ b/bin/odoo-helper
@@ -139,7 +139,9 @@ function update_odoo_helper_scripts {
         git pull;
     else
         git fetch -q origin;
-        git checkout -q origin/$scripts_branch;
+        if ! git checkout -q origin/$scripts_branch; then
+            git checkout -q $scripts_branch;
+        fi
     fi
 
     # update odoo-helper bin links

--- a/bin/odoo-helper
+++ b/bin/odoo-helper
@@ -63,6 +63,7 @@ function print_usage {
         db [--help]                              - database management (list, create, drop, etc...)
         tr [--help]                              - manage translations (import, export, load, ...)
         postgres [--help]                        - manage local instance of postgresql server
+        install [--help]                         - install related stuff (sys-deps, ...)
         generate_requirements [addons dir]       - parse addons dir, find all addons that are
                                                    git repositories and print odoo-requirements.txt content
                                                    file content suitable for *fetch* subcommand.
@@ -272,6 +273,11 @@ function odoo_helper_main {
             postgres)
                 shift;
                 postgres_command "$@";
+                exit;
+            ;;
+            install)
+                shift;
+                install_entry_point "$@";
                 exit;
             ;;
             print_config)

--- a/bin/odoo-helper
+++ b/bin/odoo-helper
@@ -134,8 +134,8 @@ function update_odoo_helper_scripts {
     if [ -z $scripts_branch ]; then
         git pull;
     else
-        git fetch origin;
-        git checkout origin/$scripts_branch;
+        git fetch -q origin;
+        git checkout -q origin/$scripts_branch;
     fi
 
     # update odoo-helper bin links
@@ -143,7 +143,7 @@ function update_odoo_helper_scripts {
     for oh_cmd in $ODOO_HELPER_BIN/*; do
         if ! command -v $(basename $oh_cmd) >/dev/null 2>&1; then
             if [ "$base_path" == /opt* ]; then
-                sudo ln -s $oh_cmd /usr/local/bin/;
+                with_sudo ln -s $oh_cmd /usr/local/bin/;
             elif [ "$base_path" == $HOME/* ]; then
                 ln -s $oh_cmd $HOME/bin;
             fi

--- a/bin/odoo-helper
+++ b/bin/odoo-helper
@@ -29,16 +29,17 @@ fi
 # Load common functions
 source $ODOO_HELPER_LIB/common.bash; 
 
-ohelper_require fetch;
-ohelper_require server;
-ohelper_require db;
-ohelper_require 'test';
-ohelper_require addons;
-ohelper_require 'install'
-ohelper_require 'git';
-ohelper_require 'odoo';
-ohelper_require 'tr';
-ohelper_require 'postgres';
+ohelper_require "fetch";
+ohelper_require "link";
+ohelper_require "server";
+ohelper_require "db";
+ohelper_require "test";
+ohelper_require "addons";
+ohelper_require "install";
+ohelper_require "git";
+ohelper_require "odoo";
+ohelper_require "tr";
+ohelper_require "postgres";
 # ----------------------------------------------------------------------------------------
 
 function print_usage {
@@ -225,7 +226,7 @@ function odoo_helper_main {
             link|link_module)
                 shift;
                 load_project_conf;
-                link_module "$@"
+                link_command "$@"
                 exit;
             ;;
             server)

--- a/bin/odoo-helper-test
+++ b/bin/odoo-helper-test
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Use odoo-helper --help for a documentation
+
+
+SCRIPT=$0;
+SCRIPT_NAME=`basename $SCRIPT`;
+F=`readlink -f $SCRIPT`;  # full script path;
+WORKDIR=`pwd`;
+
+# load basic conf
+if [ -f "/etc/odoo-helper.conf" ]; then
+    source "/etc/odoo-helper.conf";
+fi
+if [ -f "$HOME/odoo-helper.conf" ]; then
+    source "$HOME/odoo-helper.conf";
+fi
+# -----------
+
+set -e;  # Fail on errors
+
+
+if [ -z $ODOO_HELPER_LIB ]; then
+    echo "Odoo-helper-scripts seems not been installed correctly.";
+    echo "Reinstall it (see Readme on https://github.com/katyukha/odoo-helper-scripts/)";
+    exit 1;
+fi
+
+$ODOO_HELPER_BIN/odoo-helper test "$@";
+

--- a/bin/odoo-install
+++ b/bin/odoo-install
@@ -264,17 +264,31 @@ function install_odoo {
 
 function generate_conf {
     # Generate configuration
-    local -A ODOO_CONF_OPTIONS=$CONF_OPTIONS;
+    local -A ODOO_CONF_OPTIONS;
+
+    for key in ${!CONF_OPTIONS[@]}; do
+        ODOO_CONF_OPTIONS[$key]=${CONF_OPTIONS[$key]};
+    done
+
+    # Add default values
     ODOO_CONF_OPTIONS[db_host]="${ODOO_CONF_OPTIONS['db_host']:-$DB_HOST}";
     ODOO_CONF_OPTIONS[db_port]="${ODOO_CONF_OPTIONS['db_port']:-False}";
     ODOO_CONF_OPTIONS[db_user]="${ODOO_CONF_OPTIONS['db_user']:-$DB_USER}";
     ODOO_CONF_OPTIONS[db_password]="${ODOO_CONF_OPTIONS['db_password']:-$DB_PASSWORD}";
-    install_generate_odoo_conf $ODOO_CONF_FILE;
+
+    # Generate conf
+    install_generate_odoo_conf $ODOO_CONF_FILE;  # imported from 'install' module
 }
 
 function generate_test_conf {
     # Generate test configuration configuration
-    local -A ODOO_CONF_OPTIONS=$TEST_CONF_OPTIONS;
+    local -A ODOO_CONF_OPTIONS;
+
+    for key in ${!TEST_CONF_OPTIONS[@]}; do
+        ODOO_CONF_OPTIONS[$key]=${TEST_CONF_OPTIONS[$key]};
+    done
+
+    # Add default values
     ODOO_CONF_OPTIONS[logfile]="${ODOO_CONF_OPTIONS['logfile']:-test-$LOG_FILE}";
     ODOO_CONF_OPTIONS[pidfile]="${ODOO_CONF_OPTIONS['pidfile']:-test-$ODOO_PID_FILE}";
     ODOO_CONF_OPTIONS[db_host]="${ODOO_CONF_OPTIONS['db_host']:-$DB_HOST}";
@@ -286,7 +300,9 @@ function generate_test_conf {
     ODOO_CONF_OPTIONS[xmlrpc_port]="${ODOO_CONF_OPTIONS['xmlrpc_port']:-8269}";
     ODOO_CONF_OPTIONS[xmlrpcs_port]="${ODOO_CONF_OPTIONS['xmlrpcs_port']:-8271}";
     ODOO_CONF_OPTIONS[longpolling_port]="${ODOO_CONF_OPTIONS['longpolling_port']:-8272}";
-    install_generate_odoo_conf $ODOO_TEST_CONF_FILE;
+
+    # Generate conf
+    install_generate_odoo_conf $ODOO_TEST_CONF_FILE;   # imported from 'install' module
 }
 
 #------------------------------------------------------------------------
@@ -307,8 +323,8 @@ install_odoo;
 
 # Generate and save odoo-helper project conf
 echo "`print_helper_config`" > $PROJECT_ROOT_DIR/$CONF_FILE_NAME;
-generate_conf;  # imported from 'install' module
-generate_test_conf;  # imported from 'install' module
+generate_conf;
+generate_test_conf;
 #---------------------------------------------
 
 echo -e "${GREENC}Odoo seems to be successfully installed!${NC}";

--- a/bin/odoo-install
+++ b/bin/odoo-install
@@ -178,24 +178,6 @@ function parse_options {
     done
 }
 
-function download_odoo {
-    local ODOO_ARCHIVE=$DOWNLOADS_DIR/odoo.$ODOO_BRANCH.tar.gz
-    if [ ! -f $ODOO_ARCHIVE ]; then
-        if [ ! -z $ODOO_REPO ] && [[ $ODOO_REPO == "https://github.com"* ]]; then
-            local repo=${ODOO_REPO%.git};
-            local repo_base=$(basename $repo);
-            ODOO_ARCHIVE=$DOWNLOADS_DIR/$repo_base.$ODOO_BRANCH.tar.gz;
-            wget -O $ODOO_ARCHIVE $repo/archive/$ODOO_BRANCH.tar.gz;
-            tar -zxf $ODOO_ARCHIVE;
-            mv ${repo_base}-${ODOO_BRANCH} $ODOO_PATH;
-        else
-            wget -O $ODOO_ARCHIVE https://github.com/odoo/odoo/archive/$ODOO_BRANCH.tar.gz;
-            tar -zxf $ODOO_ARCHIVE;
-            mv odoo-$ODOO_BRANCH $ODOO_PATH;
-        fi
-    fi
-}
-
 function install_odoo {
     local save_dir=`pwd`;
     cd "$PROJECT_ROOT_DIR";
@@ -203,7 +185,7 @@ function install_odoo {
     # if not installed odoo, install it
     if [ ! -d $ODOO_PATH ]; then
         if [ "$DOWNLOAD_ARCHIVE" == "on" ]; then
-            download_odoo;
+            install_download_odoo;
         else
             install_clone_odoo;
         fi

--- a/bin/odoo-install
+++ b/bin/odoo-install
@@ -40,10 +40,6 @@ install_preconfigure_env;
 declare -A CONF_OPTIONS;
 declare -A TEST_CONF_OPTIONS;
 
-# Default configs
-USE_SYSTEM_SITE_PACKAGES=on;
-
-
 function print_usage {
     echo "Bash script to instal dev version of Odoo in local environment
 
@@ -58,11 +54,6 @@ function print_usage {
          ODOO_BRANCH         - allow to clone specified branch. Current val is $ODOO_BRANCH
          ODOO_DOWNLOAD_ARCHIVE - (on|off) if on then only archive will be downloaded
                                  not clonned. Current value is '$DOWNLOAD_ARCHIVE'
-         ODOO_SHALLOW_CLONE  - (on|off) allow or disallow shallow clone.
-                               signifianly increases performance, but have some limitations.
-                               If ODOO_DOWNLOAD_ARCHIVE option is on, then this option
-                               has no effect
-                               Current value is: $SHALLOW_CLONE
          ODOO_DBHOST         - allow to specify Postgresql's server host.
                                Current value: $DB_HOST
          ODOO_DBUSER         - allow to specify user to connect to DB as.
@@ -78,18 +69,13 @@ function print_usage {
          -b|--branch <branch>          - specify odoo branch to install. default: $ODOO_BRANCH
                                          Normaly it is same as odoo version, but if You want to install odoo
                                          from diferent branch, use this option.
-         --extra-utils                 - install extra python packages. (for example 'erppeek', which
-                                         is used by odoo-helper script to manage databases)
-         --install-sys-deps            - (requires sudo) (debian only) (experimental).
+         --sys-deps                    - (requires sudo) (debian only) (experimental).
                                          Attempt to install system dependencies.
-         --install-and-conf-postgres   - (requires sudo) (debian only) (experimental)
+         --postgres                    - (requires sudo) (debian only) (experimental)
                                          Install postgresql server and create role for Odoo.
          --download-archive on|off     - if on, then odoo will be downloaded as archive. it is faster
                                          if You want to clone Odoo repository set this option to 'off'
                                          Default: $DOWNLOAD_ARCHIVE
-         --use-shallow-clone on|off    - if not set 'download-archive' then, this option may increase
-                                         download speed using --depth=1 option in git clone. this will
-                                         download all by one commit. Default: $SHALLOW_CLONE
          --db-host <host>              - database host to be used in settings. default: $DB_HOST
          --db-user <user>              - database user to be used in settings. default: $DB_USER
          --db-pass <password>          - database password to be used in settings. default: odoo
@@ -102,7 +88,7 @@ function print_usage {
 
     Prerequirements:
          Next packages must be installed system-wide
-         (or use --install-sys-deps option to install them during installation process):
+         (or use --sys-deps option to install them during installation process):
              - virtualenv
              - postgresql-client
              - python-dev
@@ -116,7 +102,7 @@ function print_usage {
     Note that, it is safe enough to run this script second time with same or similar args
     if it breaks somehow. It will automaticaly detect if odoo sources were downloaded or
     virtual environment created and will not do this operations second time.
-    So for example if you use option --install-sys-deps and some dependencies cannot be installed
+    So for example if you use option --sys-deps and some dependencies cannot be installed
     you can install them manualy and retry this script with or without thi option and You will not
     wast time waiting odoo sources to be downloaded again.
 
@@ -147,21 +133,14 @@ function parse_options {
                 ODOO_BRANCH=$2;
                 shift;
             ;;
-            --extra-utils)
-                INSTALL_EXTRA_UTILS=1;
-            ;;
-            --install-sys-deps)
+            --sys-deps)
                 INSTALL_SYS_DEPS=1;
             ;;
-            --install-and-conf-postgres)
+            --postgres)
                 INSTALL_AND_CONFIGURE_POSTGRESQL=1;
             ;;
             --download-archive)
                 DOWNLOAD_ARCHIVE=$2;
-                shift;
-            ;;
-            --use-shallow-clone)
-                SHALLOW_CLONE=$2;
                 shift;
             ;;
             --db-host)

--- a/bin/odoo-install
+++ b/bin/odoo-install
@@ -34,9 +34,6 @@ ohelper_require 'install'
 # ----------------------------------------------------------------------------------------
 
 
-# Check environment for config
-install_preconfigure_env;
-
 declare -A CONF_OPTIONS;
 declare -A TEST_CONF_OPTIONS;
 
@@ -129,6 +126,10 @@ function parse_options {
                 ODOO_REPO=$2;
                 shift;
             ;;
+            --odoo-version)
+                ODOO_VERSION=$2;
+                shift;
+            ;;
             --branch|-b)
                 ODOO_BRANCH=$2;
                 shift;
@@ -172,6 +173,9 @@ function parse_options {
                 shift;
             ;;
             -h|--help|help)
+                # Check environment for config
+                install_preconfigure_env;
+
                 print_usage;
                 exit 0;
             ;;
@@ -290,6 +294,9 @@ function generate_test_conf {
 
 # Install process
 parse_options $@;
+
+# Check environment to get values not provided via command line args
+install_preconfigure_env;
 
 # Directory and file paths
 PROJECT_ROOT_DIR=${PROJECT_ROOT_DIR:-$WORKDIR/odoo-$ODOO_BRANCH};

--- a/bin/odoo-install
+++ b/bin/odoo-install
@@ -192,12 +192,12 @@ function parse_options {
                 VERBOSE=1;
             ;;
             --conf-opt-*)
-                local opt_name=$(echo '--conf-opt-xmlrpc_port' | sed 's/--conf-opt-\(.*\)/\1/')
+                local opt_name="${key#--conf-opt-}"
                 CONF_OPTIONS[$opt_name]=$2;
                 shift;
             ;;
             --test-conf-opt-*)
-                local opt_name=$(echo '--test-conf-opt-xmlrpc_port' | sed 's/--test-conf-opt-\(.*\)/\1/')
+                local opt_name="${key#--test-conf-opt-}"
                 TEST_CONF_OPTIONS[$opt_name]=$2;
                 shift;
             ;;

--- a/bin/odoo-install
+++ b/bin/odoo-install
@@ -74,14 +74,16 @@ function print_usage {
          -i|--install-dir <dir>        - directory to install odoo in. default: $PROJECT_ROOT_DIR
          --odoo-repo <git repo>        - git repository to get Odoo from. default: $ODOO_REPO
                                          Used only if *download-archive* set to *off*
-         -b|--branch <branch>          - specify odoo branch to clone. default: $ODOO_BRANCH
+         --odoo-version <odoo version> - odoo version to install. default: $ODOO_VERSION
+         -b|--branch <branch>          - specify odoo branch to install. default: $ODOO_BRANCH
+                                         Normaly it is same as odoo version, but if You want to install odoo
+                                         from diferent branch, use this option.
          --extra-utils                 - install extra python packages. (for example 'erppeek', which
                                          is used by odoo-helper script to manage databases)
          --install-sys-deps            - (requires sudo) (debian only) (experimental).
                                          Attempt to install system dependencies.
          --install-and-conf-postgres   - (requires sudo) (debian only) (experimental)
                                          Install postgresql server and create role for Odoo.
-         --use-system-packages on|off  - allow virtualenv use system packages. (default: enabled)
          --download-archive on|off     - if on, then odoo will be downloaded as archive. it is faster
                                          if You want to clone Odoo repository set this option to 'off'
                                          Default: $DOWNLOAD_ARCHIVE
@@ -91,10 +93,6 @@ function print_usage {
          --db-host <host>              - database host to be used in settings. default: $DB_HOST
          --db-user <user>              - database user to be used in settings. default: $DB_USER
          --db-pass <password>          - database password to be used in settings. default: odoo
-         --use-unbuffer                - if set, then 'unbuffer' command from 'expect' package will be used
-                                         otherwise standard 'exec' will be used to run odoo server
-                                         this helps to make odoo server think that it runs in terminal thus
-                                         it provides colored output.
          -y                            - Answer yes on any question. (used in apt-get commands
                                          when --install-sys-deps option supplied.)
 
@@ -158,10 +156,6 @@ function parse_options {
             --install-and-conf-postgres)
                 INSTALL_AND_CONFIGURE_POSTGRESQL=1;
             ;;
-            --use-system-packages)
-                USE_SYSTEM_SITE_PACKAGES=$2;
-                shift
-            ;;
             --download-archive)
                 DOWNLOAD_ARCHIVE=$2;
                 shift;
@@ -181,9 +175,6 @@ function parse_options {
             --db-pass)
                 DB_PASSWORD=$2;
                 shift;
-            ;;
-            --use-unbuffer)
-                USE_UNBUFFER=1;
             ;;
             -y)
                 ALWAYS_ANSWER_YES=1;

--- a/bin/odoo-install
+++ b/bin/odoo-install
@@ -215,12 +215,21 @@ function parse_options {
 }
 
 function download_odoo {
-   local ODOO_ARCHIVE=$DOWNLOADS_DIR/odoo.$ODOO_BRANCH.tar.gz
-   if [ ! -f $ODOO_ARCHIVE ]; then
-       wget -O $ODOO_ARCHIVE https://github.com/odoo/odoo/archive/$ODOO_BRANCH.tar.gz;
-   fi
-   tar -zxf $ODOO_ARCHIVE;
-   mv odoo-$ODOO_BRANCH $ODOO_PATH;
+    local ODOO_ARCHIVE=$DOWNLOADS_DIR/odoo.$ODOO_BRANCH.tar.gz
+    if [ ! -f $ODOO_ARCHIVE ]; then
+        if [ ! -z $ODOO_REPO ] && [[ $ODOO_REPO == "https://github.com"* ]]; then
+            local repo=${ODOO_REPO%.git};
+            local repo_base=$(basename $repo);
+            ODOO_ARCHIVE=$DOWNLOADS_DIR/$repo_base.$ODOO_BRANCH.tar.gz;
+            wget -O $ODOO_ARCHIVE $repo/archive/$ODOO_BRANCH.tar.gz;
+            tar -zxf $ODOO_ARCHIVE;
+            mv ${repo_base}-${ODOO_BRANCH} $ODOO_PATH;
+        else
+            wget -O $ODOO_ARCHIVE https://github.com/odoo/odoo/archive/$ODOO_BRANCH.tar.gz;
+            tar -zxf $ODOO_ARCHIVE;
+            mv odoo-$ODOO_BRANCH $ODOO_PATH;
+        fi
+    fi
 }
 
 function install_odoo {

--- a/bin/odoo-install
+++ b/bin/odoo-install
@@ -66,10 +66,6 @@ function print_usage {
          -b|--branch <branch>          - specify odoo branch to install. default: $ODOO_BRANCH
                                          Normaly it is same as odoo version, but if You want to install odoo
                                          from diferent branch, use this option.
-         --sys-deps                    - (requires sudo) (debian only) (experimental).
-                                         Attempt to install system dependencies.
-         --postgres                    - (requires sudo) (debian only) (experimental)
-                                         Install postgresql server and create role for Odoo.
          --download-archive on|off     - if on, then odoo will be downloaded as archive. it is faster
                                          if You want to clone Odoo repository set this option to 'off'
                                          Default: $DOWNLOAD_ARCHIVE
@@ -133,12 +129,6 @@ function parse_options {
             --branch|-b)
                 ODOO_BRANCH=$2;
                 shift;
-            ;;
-            --sys-deps)
-                INSTALL_SYS_DEPS=1;
-            ;;
-            --postgres)
-                INSTALL_AND_CONFIGURE_POSTGRESQL=1;
             ;;
             --download-archive)
                 DOWNLOAD_ARCHIVE=$2;
@@ -210,16 +200,6 @@ function install_odoo {
     local save_dir=`pwd`;
     cd "$PROJECT_ROOT_DIR";
 
-    # Install prerequirements if option --install-sys-deps enabled
-    if [ ! -z $INSTALL_SYS_DEPS ]; then
-        install_system_prerequirements;
-    fi
-
-    # Install and configure postgresql
-    if [ ! -z $INSTALL_AND_CONFIGURE_POSTGRESQL ]; then
-        install_and_configure_postgresql;
-    fi
-
     # if not installed odoo, install it
     if [ ! -d $ODOO_PATH ]; then
         if [ "$DOWNLOAD_ARCHIVE" == "on" ]; then
@@ -227,11 +207,6 @@ function install_odoo {
         else
             install_clone_odoo;
         fi
-    fi
-
-    # Install system dependencies if asked
-    if [ ! -z $INSTALL_SYS_DEPS ]; then
-        install_sys_deps;
     fi
 
     # Install virtual environment

--- a/install-system.bash
+++ b/install-system.bash
@@ -30,7 +30,7 @@ ODOO_HELPER_BIN=${ODOO_HELPER_BIN:-$INSTALL_PATH/bin};
 
 # clone repo
 if [ ! -d $INSTALL_PATH ]; then
-    git clone https://github.com/katyukha/odoo-helper-scripts $INSTALL_PATH;
+    git clone -q https://github.com/katyukha/odoo-helper-scripts $INSTALL_PATH;
     # TODO: may be it is good idea to pull changes from repository if it is already exists?
     # TODO: implement here some sort of upgrade mechanism?
 fi

--- a/install-system.bash
+++ b/install-system.bash
@@ -33,7 +33,7 @@ ODOO_HELPER_BIN=${ODOO_HELPER_BIN:-$INSTALL_PATH/bin};
 # clone repo
 if [ ! -d $INSTALL_PATH ]; then
     git clone -q https://github.com/katyukha/odoo-helper-scripts $INSTALL_PATH;
-    git checkout -q $ODOO_HELPER_BRANCH;
+    (cd $INSTALL_PATH && git checkout -q $ODOO_HELPER_BRANCH);
     # TODO: may be it is good idea to pull changes from repository if it is already exists?
     # TODO: implement here some sort of upgrade mechanism?
 fi

--- a/install-system.bash
+++ b/install-system.bash
@@ -1,12 +1,17 @@
 #!/bin/bash
 
 # Simple script to install odoo-helper-script system-wide
+if [[ $UID != 0 ]]; then
+    echo "Please run this script with sudo:"
+    echo "sudo $0 $*"
+    exit 1
+fi
 
 
 set -e;  # Fail on each error
 
 if ! command -v git >/dev/null 2>&1; then
-    sudo apt-get install -y git
+    apt-get install -y git
 fi
 
 # define vars
@@ -25,27 +30,27 @@ ODOO_HELPER_BIN=${ODOO_HELPER_BIN:-$INSTALL_PATH/bin};
 
 # clone repo
 if [ ! -d $INSTALL_PATH ]; then
-    sudo git clone https://github.com/katyukha/odoo-helper-scripts $INSTALL_PATH;
+    git clone https://github.com/katyukha/odoo-helper-scripts $INSTALL_PATH;
     # TODO: may be it is good idea to pull changes from repository if it is already exists?
     # TODO: implement here some sort of upgrade mechanism?
 fi
 
 # install odoo-helper user config
 if [ ! -f "$ODOO_HELPER_SYS_CONF" ]; then
-    sudo echo "ODOO_HELPER_ROOT=$INSTALL_PATH;"   >> $ODOO_HELPER_SYS_CONF;
-    sudo echo "ODOO_HELPER_BIN=$ODOO_HELPER_BIN;" >> $ODOO_HELPER_SYS_CONF;
-    sudo echo "ODOO_HELPER_LIB=$ODOO_HELPER_LIB;" >> $ODOO_HELPER_SYS_CONF;
+    echo "ODOO_HELPER_ROOT=$INSTALL_PATH;"   >> $ODOO_HELPER_SYS_CONF;
+    echo "ODOO_HELPER_BIN=$ODOO_HELPER_BIN;" >> $ODOO_HELPER_SYS_CONF;
+    echo "ODOO_HELPER_LIB=$ODOO_HELPER_LIB;" >> $ODOO_HELPER_SYS_CONF;
 fi
 
 # add odoo-helper-bin to path
 for oh_cmd in $ODOO_HELPER_BIN/*; do
     if ! command -v $(basename $oh_cmd) >/dev/null 2>&1; then
-        sudo ln -s $oh_cmd /usr/local/bin/;
+        ln -s $oh_cmd /usr/local/bin/;
     fi
 done
     
 echo "Odoo-helper-scripts seems to be correctly installed system-wide!";
 echo "Install path is $INSTALL_PATH";
-echo "To update odoo-helper-scripts, just go to install path, and pull last repo changes:";
-echo "    (cd $INSTALL_PATH && sudo git pull)";
+echo "To update odoo-helper-scripts, just run following command:";
+echo "    odoo-helper system update";
 

--- a/install-system.bash
+++ b/install-system.bash
@@ -13,7 +13,7 @@ ODOO_HELPER_BRANCH=${1:-master}
 set -e;  # Fail on each error
 
 if ! command -v git >/dev/null 2>&1; then
-    apt-get install -y git
+    apt-get install -y git;
 fi
 
 # define vars

--- a/install-system.bash
+++ b/install-system.bash
@@ -7,6 +7,8 @@ if [[ $UID != 0 ]]; then
     exit 1
 fi
 
+# Get odoo-helper branch. Default is master
+ODOO_HELPER_BRANCH=${1:-master}
 
 set -e;  # Fail on each error
 
@@ -30,7 +32,8 @@ ODOO_HELPER_BIN=${ODOO_HELPER_BIN:-$INSTALL_PATH/bin};
 
 # clone repo
 if [ ! -d $INSTALL_PATH ]; then
-    git clone -q https://github.com/katyukha/odoo-helper-scripts $INSTALL_PATH;
+    git clone -q -b $ODOO_HELPER_BRANCH \
+        https://github.com/katyukha/odoo-helper-scripts $INSTALL_PATH;
     # TODO: may be it is good idea to pull changes from repository if it is already exists?
     # TODO: implement here some sort of upgrade mechanism?
 fi

--- a/install-system.bash
+++ b/install-system.bash
@@ -32,8 +32,8 @@ ODOO_HELPER_BIN=${ODOO_HELPER_BIN:-$INSTALL_PATH/bin};
 
 # clone repo
 if [ ! -d $INSTALL_PATH ]; then
-    git clone -q -b $ODOO_HELPER_BRANCH \
-        https://github.com/katyukha/odoo-helper-scripts $INSTALL_PATH;
+    git clone -q https://github.com/katyukha/odoo-helper-scripts $INSTALL_PATH;
+    git checkout -q $ODOO_HELPER_BRANCH;
     # TODO: may be it is good idea to pull changes from repository if it is already exists?
     # TODO: implement here some sort of upgrade mechanism?
 fi

--- a/install-user.bash
+++ b/install-user.bash
@@ -31,7 +31,7 @@ ODOO_HELPER_BIN=${ODOO_HELPER_BIN:-$INSTALL_PATH/bin};
 # clone repo
 if [ ! -d $INSTALL_PATH ]; then
     git clone -q https://github.com/katyukha/odoo-helper-scripts $INSTALL_PATH;
-    git checkout -q $ODOO_HELPER_BRANCH;
+    (cd $INSTALL_PATH && git checkout -q $ODOO_HELPER_BRANCH);
     # TODO: may be it is good idea to pull changes from repository if it is already exists?
     # TODO: implement here some sort of upgrade mechanism?
 fi

--- a/install-user.bash
+++ b/install-user.bash
@@ -11,6 +11,9 @@ if ! command -v git >/dev/null 2>&1; then
     exit 1;
 fi
 
+# Get odoo-helper branch. Default is master
+ODOO_HELPER_BRANCH=${1:-master}
+
 # define vars
 ODOO_HELPER_USER_CONF="$HOME/odoo-helper.conf";
 
@@ -27,7 +30,8 @@ ODOO_HELPER_BIN=${ODOO_HELPER_BIN:-$INSTALL_PATH/bin};
 
 # clone repo
 if [ ! -d $INSTALL_PATH ]; then
-    git clone https://github.com/katyukha/odoo-helper-scripts $INSTALL_PATH;
+    git clone -q -b $ODOO_HELPER_BRANCH \
+        https://github.com/katyukha/odoo-helper-scripts $INSTALL_PATH;
     # TODO: may be it is good idea to pull changes from repository if it is already exists?
     # TODO: implement here some sort of upgrade mechanism?
 fi

--- a/install-user.bash
+++ b/install-user.bash
@@ -30,8 +30,8 @@ ODOO_HELPER_BIN=${ODOO_HELPER_BIN:-$INSTALL_PATH/bin};
 
 # clone repo
 if [ ! -d $INSTALL_PATH ]; then
-    git clone -q -b $ODOO_HELPER_BRANCH \
-        https://github.com/katyukha/odoo-helper-scripts $INSTALL_PATH;
+    git clone -q https://github.com/katyukha/odoo-helper-scripts $INSTALL_PATH;
+    git checkout -q $ODOO_HELPER_BRANCH;
     # TODO: may be it is good idea to pull changes from repository if it is already exists?
     # TODO: implement here some sort of upgrade mechanism?
 fi

--- a/lib/addons.bash
+++ b/lib/addons.bash
@@ -351,7 +351,7 @@ function addons_test_installed {
         python_cmd="$python_cmd is_installed=bool(env['ir.module.module'].search([('name', 'in', '$addons'.split(',')),('state', '=', 'installed')], count=1));"
         python_cmd="$python_cmd exit(not is_installed);"
 
-        if execu python -c "\"$python_cmd\""; then
+        if execu python -c "\"$python_cmd\"" >/dev/null 2>&1; then
             echo "$db";
         fi
     done

--- a/lib/addons.bash
+++ b/lib/addons.bash
@@ -39,7 +39,14 @@ function addons_get_addon_path {
 # addons_is_installable <addon_path>
 function addons_is_installable {
     local addon_path=$1;
-    if python -c "exit(not eval(open('$1/__openerp__.py', 'rt').read()).get('installable', True))"; then
+    if [ -f "$1/__openerp__.py" ]; then
+        local manifest_file="$1/__openerp__.py";
+    elif [ -f "$1/__manifest__.py" ]; then
+        local manifest_file="$1/__manifest__.py";
+    else
+        return 2
+    fi
+    if python -c "exit(not eval(open('$manifest_file', 'rt').read()).get('installable', True))"; then
         return 0;
     else
         return 1;

--- a/lib/addons.bash
+++ b/lib/addons.bash
@@ -34,6 +34,8 @@ function addons_get_addon_path {
 
 # Check if addon is installable
 #
+# Return 0 if addon is installable else 1;
+#
 # addons_is_installable <addon_path>
 function addons_is_installable {
     local addon_path=$1;

--- a/lib/addons.bash
+++ b/lib/addons.bash
@@ -46,10 +46,10 @@ function addons_get_installed_addons {
     execu python -c "\"$python_cmd\"";
 }
 
-# Update list of addons visible in system
+# Update list of addons visible in system (for single db)
 # NOTE: Odoo 8.0+ required
 # addons_update_module_list <db> [conf_file]
-function addons_update_module_list {
+function addons_update_module_list_db {
     local db=$1;
     local conf_file=${2:-$ODOO_CONF_FILE};
 
@@ -61,6 +61,24 @@ function addons_update_module_list {
     python_cmd="$python_cmd print('updated: %d\nadded: %d\n' % tuple(res));";
 
     execu python -c "\"$python_cmd\"";
+}
+
+
+# Update list of addons visible in system for db or all databases
+# NOTE: Odoo 8.0+ required
+# addons_update_module_list <db> [conf_file]
+function addons_update_module_list {
+    local db=$1;
+
+    if [ ! -z $db ]; then
+        echo -e "${BLUEC}Updating module list for ${YELLOWC}$db${NC}";
+        addons_update_module_list_db $db;
+    else
+        for db in $(odoo_db_list); do
+            echo -e "${BLUEC}Updating module list for ${YELLOWC}$db${NC}";
+            addons_update_module_list_db $db;
+        done
+    fi
 }
 
 # List addons repositories
@@ -301,7 +319,7 @@ function addons_command {
         $SCRIPT_NAME addons status --help                 - show addons status
         $SCRIPT_NAME addons update [-d <db>] <name>       - update some addon
         $SCRIPT_NAME addons install [-d <db>] <name>      - update some addon
-        $SCRIPT_NAME addons update-list <db>              - update list of addons
+        $SCRIPT_NAME addons update-list [db>              - update list of addons
         $SCRIPT_NAME addons --help                        - show this help message
 
     ";

--- a/lib/addons.bash
+++ b/lib/addons.bash
@@ -364,7 +364,7 @@ function addons_install_update {
     fi
 
     for db in $dbs; do
-        if server_run -d $db $cmd_opt $todo_addons --stop-after-init; then
+        if server_run -d $db $cmd_opt $todo_addons --stop-after-init --no-xmlrpc; then
             echo -e "${LBLUEC}Update for '$db':${NC} ${GREENC}OK${NC}";
         else
             echo -e "${LBLUEC}Update for '$db':${NC} ${REDC}FAIL${NC}";

--- a/lib/addons.bash
+++ b/lib/addons.bash
@@ -255,14 +255,19 @@ function addons_install_update {
         dbs=$(odoo_db_list);
     fi
 
+    [ "$cmd" == "install" ] && local cmd_opt="-i";
+    [ "$cmd" == "update" ]  && local cmd_opt="-u";
+
+    if [ -z $cmd_opt ]; then
+        echo -e "${REDC}ERROR: Wrong command '$cmd'${NC}";
+    fi
+
     server_stop;
     for db in $dbs; do
-        if [ "$cmd" == "install" ]; then
-            server_run -d $db -i $todo_addons --stop-after-init
-        elif [ "$cmd" == "update" ]; then
-            server_run -d $db -u $todo_addons --stop-after-init
+        if server_run -d $db $cmd_opt $todo_addons --stop-after-init; then
+            echo -e "${LBLUEC}Update for '$db':${NC} ${GREENC}OK${NC}";
         else
-            echo -e "${REDC}ERROR: Wrong command '$cmd'${NC}";
+            echo -e "${LBLUEC}Update for '$db':${NC} ${REDC}FAIL${NC}";
         fi
     done
     server_start;

--- a/lib/addons.bash
+++ b/lib/addons.bash
@@ -86,6 +86,8 @@ function addons_update_module_list {
 # List addons in specified directory
 #
 # addons_list_in_directory <directory to search odoo addons in>
+#
+# Note: this funtion lists addon paths
 function addons_list_in_directory {
     local addons_path=${1:-$ADDONS_DIR};
     if [ -d $addons_path ]; then
@@ -96,6 +98,19 @@ function addons_list_in_directory {
         done
     fi
 }
+
+
+# List addons in specified directory by name
+# This function prints only name of addons found in specified dir.
+# Not paths!
+#
+# addons_list_in_directory_by_name <directory to search odoo addons in>
+function addons_list_in_directory_by_name {
+    for addon_path in $(addons_list_in_directory $1); do
+        echo "$(basename $addon_path)";
+    done
+}
+
 
 # List addons repositories
 # Note that this function list only addons that are under git control

--- a/lib/addons.bash
+++ b/lib/addons.bash
@@ -251,6 +251,7 @@ function addons_show_status {
         # Display addon status
         echo -e "Addon status for ${BLUEC}$addon_repo${NC}'";
         echo -e "\tRepo branch:          ${git_status[0]}";
+        echo -e "\tRepo remote:          $(git_get_remote_url $addon_repo)";
         [ ${git_status[1]} != "." ] && echo -e "\t${YELLOWC}Remote: ${git_status[1]}${NC}";
         [ ${git_status[1]} != "." ] && echo -e "\t${YELLOWC}Upstream: ${git_status[2]}${NC}";
         [ ${git_status[3]} -eq 1 ]  && echo -e "\t${GREENC}Repo is clean!${NC}";

--- a/lib/addons.bash
+++ b/lib/addons.bash
@@ -302,11 +302,15 @@ function addons_install_update {
     shift;
     local usage="Usage:
 
-        $SCRIPT_NAME addons $cmd [-d <db>] <addons>    - $cmd some addons
+        $SCRIPT_NAME addons $cmd [-d <db>] [--no-restart] <addons>    - $cmd some addons
         $SCRIPT_NAME addons $cmd --help
 
         if -d <db> argument is not passed '$cmd' will be executed on all databases
         <addons> is comma-separated or space-separated list of addons
+
+        if --no-restart option passed, then do not restart server.
+        By default, befor updating \ installing addons server will be stopped,
+        and started on success
 
     ";
     local dbs="";
@@ -318,6 +322,9 @@ function addons_install_update {
             -d|--db)
                 dbs=$dbs$'\n'$2;
                 shift;
+            ;;
+            --no-restart)
+                local no_restart_server=1;
             ;;
             -h|--help|help)
                 echo "$usage";
@@ -351,7 +358,7 @@ function addons_install_update {
     fi
 
     # Stop server if it is running
-    if [ $(server_get_pid) -gt 0 ]; then
+    if [ -z $no_restart_server ] && [ $(server_get_pid) -gt 0 ]; then
         server_stop;
         local need_start=1;
     fi
@@ -365,7 +372,7 @@ function addons_install_update {
     done
 
     # Start server again if it was stopped
-    if [ ! -z $need_start ]; then
+    if [ -z $no_restart_server ] && [ ! -z $need_start ]; then
         server_start;
     fi
 }
@@ -396,8 +403,8 @@ function addons_command {
         $SCRIPT_NAME addons check_updates [addons path]   - Check for git updates of addons and displays status
         $SCRIPT_NAME addons pull_updates [addons path]    - Pull changes from git repos
         $SCRIPT_NAME addons status --help                 - show addons status
-        $SCRIPT_NAME addons update [-d <db>] <name>       - update some addon
-        $SCRIPT_NAME addons install [-d <db>] <name>      - update some addon
+        $SCRIPT_NAME addons update --help                 - update some addon[s]
+        $SCRIPT_NAME addons install --help                - install some addon[s]
         $SCRIPT_NAME addons update-list [db]              - update list of addons
         $SCRIPT_NAME addons test-installed <addon>        - lists databases this addon is installed in
         $SCRIPT_NAME addons --help                        - show this help message

--- a/lib/addons.bash
+++ b/lib/addons.bash
@@ -12,6 +12,7 @@ ohelper_require 'git';
 ohelper_require 'db';
 ohelper_require 'server';
 ohelper_require 'odoo';
+ohelper_require 'fetch';
 # ----------------------------------------------------------------------------------------
 
 set -e; # fail on errors
@@ -66,7 +67,7 @@ function addons_update_module_list_db {
 
 # Update list of addons visible in system for db or all databases
 # NOTE: Odoo 8.0+ required
-# addons_update_module_list <db> [conf_file]
+# addons_update_module_list [db] [conf_file]
 function addons_update_module_list {
     local db=$1;
 
@@ -154,10 +155,12 @@ function addons_git_pull_updates {
         IFS=$'\n' git_status=( $(git_parse_status $addon_repo || echo '') );
         local git_remote_status=${git_status[1]};
         if [[ $git_remote_status == _BEHIND_* ]] && [[ $git_remote_status != *_AHEAD_* ]]; then
-            (cd $addon_repo && git pull);
+            (cd $addon_repo && git pull && link_module .);
         fi
-
     done
+
+    # update list available modules for all databases
+    addons_update_module_list
 }
 
 

--- a/lib/addons.bash
+++ b/lib/addons.bash
@@ -158,7 +158,9 @@ function addons_git_fetch_updates {
     local addons_dir=${1:-$ADDONS_DIR};
     # fetch updates for each addon repo
     for addon_repo in $(addons_list_repositories $addons_dir); do
-        (cd $addon_repo && git fetch) || true;
+        if ! (cd $addon_repo && git fetch); then
+            echo -e "${REDC} fetch updates error: $addon_repo${NC}";
+        fi
     done
 }
 

--- a/lib/addons.bash
+++ b/lib/addons.bash
@@ -32,6 +32,18 @@ function addons_get_addon_path {
     echo "$addon_path";
 }
 
+# Check if addon is installable
+#
+# addons_is_installable <addon_path>
+function addons_is_installable {
+    local addon_path=$1;
+    if python -c "exit(not eval(open('$1/__openerp__.py', 'rt').read()).get('installable', True))"; then
+        return 0;
+    else
+        return 1;
+    fi
+}
+
 # Get list of installed addons
 # NOTE: Odoo 8.0+ required
 # addons_get_installed_addons <db> [conf_file]

--- a/lib/addons.bash
+++ b/lib/addons.bash
@@ -32,6 +32,7 @@ function addons_get_addon_path {
 }
 
 # Get list of installed addons
+# NOTE: Odoo 8.0+ required
 # addons_get_installed_addons <db> [conf_file]
 function addons_get_installed_addons {
     local db=$1;
@@ -46,6 +47,7 @@ function addons_get_installed_addons {
 }
 
 # Update list of addons visible in system
+# NOTE: Odoo 8.0+ required
 # addons_update_module_list <db> [conf_file]
 function addons_update_module_list {
     local db=$1;

--- a/lib/addons.bash
+++ b/lib/addons.bash
@@ -329,7 +329,12 @@ function addons_install_update {
         echo -e "${REDC}ERROR: Wrong command '$cmd'${NC}";
     fi
 
-    server_stop;
+    # Stop server if it is running
+    if [ $(server_get_pid) -gt 0 ]; then
+        server_stop;
+        local need_start=1;
+    fi
+
     for db in $dbs; do
         if server_run -d $db $cmd_opt $todo_addons --stop-after-init; then
             echo -e "${LBLUEC}Update for '$db':${NC} ${GREENC}OK${NC}";
@@ -337,7 +342,11 @@ function addons_install_update {
             echo -e "${LBLUEC}Update for '$db':${NC} ${REDC}FAIL${NC}";
         fi
     done
-    server_start;
+
+    # Start server again if it was stopped
+    if [ ! -z $need_start ]; then
+        server_start;
+    fi
 }
 
 

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -8,7 +8,7 @@ declare -A ODOO_HELPER_IMPORTED_MODULES;
 ODOO_HELPER_IMPORTED_MODULES[common]=1
 
 # Define version number
-ODOO_HELPER_VERSION="0.0.10"
+ODOO_HELPER_VERSION="0.0.11"
 
 # if odoo-helper root conf is not loaded yet, try to load it
 # This is useful when this lib is used by external utils,

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -105,7 +105,7 @@ function execu {
     # Check unbuffer option
     if [ ! -z $USE_UNBUFFER ] && ! command -v unbuffer >/dev/null 2>&1; then
         echo -e "${REDC}Command 'unbuffer' not found. Install it to use --use-unbuffer option";
-        echo -e "It could be installed by installing package expect-dev";
+        echo -e "It could be installed by installing package *expect-dev*";
         echo -e "Using standard behavior${NC}";
         USE_UNBUFFER=;
     fi

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -280,3 +280,12 @@ function with_sudo {
         $@
     fi
 }
+
+# Join arguments useing arg $1 as separator
+# join_by , a "b c" d -> a,b c,d
+# origin: http://stackoverflow.com/questions/1527049/bash-join-elements-of-an-array#answer-17841619
+function join_by {
+    local IFS="$1";
+    shift;
+    echo "$*";
+}

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -79,12 +79,7 @@ function ohelper_require {
 
 # Simple function to exec command in virtual environment if required
 function execv {
-    #if [ ! -z $VIRTUAL_ENV ]; then
-        ## virtual env already activated, so no need to activate it again
-        #local no_activate_venv=1;
-    #fi
-
-    if [ ! -z $VENV_DIR ] && [ -z $no_activate_venv ]; then
+    if [ ! -z $VENV_DIR ]; then
         source $VENV_DIR/bin/activate;
     fi
 
@@ -96,7 +91,7 @@ function execv {
     fi
 
     # deactivate virtual environment
-    if [ ! -z $VENV_DIR ] && [ ! -z $VIRTUAL_ENV ] && [ -z $no_activate_venv ]; then
+    if [ ! -z $VENV_DIR ] && [ ! -z $VIRTUAL_ENV ]; then
         deactivate;
     fi
 

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -270,3 +270,13 @@ function load_project_conf {
         echo -e "${REDC}WARNING: no project config file found${NC}";
     fi
 }
+
+# with_sudo <args>
+# Run command with sudo if required
+function with_sudo {
+    if [[ $UID != 0 ]]; then
+        sudo $@;
+    else
+        $@
+    fi
+}

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -253,7 +253,11 @@ function config_default_vars {
 function is_odoo_module {
     if [ ! -d $1 ]; then
        return 1;
-    elif [ -f "$1/__openerp__.py" ] || [ -f "$1/__odoo__.py" ] || [ -f "$1/__terp__.py" ]; then
+    elif [ -f "$1/__manifest__.py" ]; then
+        # Odoo 10.0+
+        return 0;
+    elif [ -f "$1/__openerp__.py" ]; then
+        # Odoo 6.0 - 9.0
         return 0;
     else
         return 1;

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -267,14 +267,17 @@ function is_odoo_module {
 
 # Load project configuration. No args prowided
 function load_project_conf {
-    local project_conf=`search_file_up $WORKDIR $CONF_FILE_NAME`;
-    if [ -f "$project_conf" ] && [ ! "$project_conf" == "$HOME/odoo-helper.conf" ]; then
-        echov -e "${LBLUEC}Loading conf${NC}: $project_conf";
-        source $project_conf;
-    fi
-
     if [ -z $PROJECT_ROOT_DIR ]; then
-        echo -e "${REDC}WARNING: no project config file found${NC}";
+        # Load project conf, only if it is not loaded yet.
+        local project_conf=`search_file_up $WORKDIR $CONF_FILE_NAME`;
+        if [ -f "$project_conf" ] && [ ! "$project_conf" == "$HOME/odoo-helper.conf" ]; then
+            echov -e "${LBLUEC}Loading conf${NC}: $project_conf";
+            source $project_conf;
+        fi
+
+        if [ -z $PROJECT_ROOT_DIR ]; then
+            echo -e "${REDC}WARNING: no project config file found${NC}";
+        fi
     fi
 }
 
@@ -295,4 +298,13 @@ function join_by {
     local IFS="$1";
     shift;
     echo "$*";
+}
+
+# Run python code
+#
+# run_python_cmd <code>
+function run_python_cmd {
+    local python_cmd="import sys; sys.path.append('$ODOO_HELPER_LIB/pylib');";
+    python_cmd="$python_cmd $1";
+    execu python -c "\"$python_cmd\"";
 }

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -79,7 +79,12 @@ function ohelper_require {
 
 # Simple function to exec command in virtual environment if required
 function execv {
-    if [ ! -z $VENV_DIR ]; then
+    #if [ ! -z $VIRTUAL_ENV ]; then
+        ## virtual env already activated, so no need to activate it again
+        #local no_activate_venv=1;
+    #fi
+
+    if [ ! -z $VENV_DIR ] && [ -z $no_activate_venv ]; then
         source $VENV_DIR/bin/activate;
     fi
 
@@ -91,7 +96,7 @@ function execv {
     fi
 
     # deactivate virtual environment
-    if [ ! -z $VENV_DIR ] && [ ! -z $VIRTUAL_ENV ]; then
+    if [ ! -z $VENV_DIR ] && [ ! -z $VIRTUAL_ENV ] && [ -z $no_activate_venv ]; then
         deactivate;
     fi
 

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -8,7 +8,7 @@ declare -A ODOO_HELPER_IMPORTED_MODULES;
 ODOO_HELPER_IMPORTED_MODULES[common]=1
 
 # Define version number
-ODOO_HELPER_VERSION="0.0.11"
+ODOO_HELPER_VERSION="0.1.0"
 
 # if odoo-helper root conf is not loaded yet, try to load it
 # This is useful when this lib is used by external utils,

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -200,6 +200,7 @@ function search_file_in {
 
 # function to print odoo-helper config
 function print_helper_config {
+    echo "ODOO_VERSION=$ODOO_VERSION;";
     echo "ODOO_BRANCH=$ODOO_BRANCH;";
     echo "PROJECT_ROOT_DIR=$PROJECT_ROOT_DIR;";
     echo "CONF_DIR=$CONF_DIR;";
@@ -217,7 +218,9 @@ function print_helper_config {
     echo "ODOO_PID_FILE=$ODOO_PID_FILE;";
     echo "BACKUP_DIR=$BACKUP_DIR;";
     echo "REPOSITORIES_DIR=$REPOSITORIES_DIR;";
-    echo "INIT_SCRIPT=$INIT_SCRIPT;";
+    if [ ! -z $INIT_SCRIPT ]; then
+        echo "INIT_SCRIPT=$INIT_SCRIPT;";
+    fi
 }
 
 

--- a/lib/db.bash
+++ b/lib/db.bash
@@ -59,7 +59,7 @@ function odoo_db_exists {
     local db_name=$1;
     local conf_file=${2:-$ODOO_CONF_FILE};
 
-    local python_cmd="import erppeek; cl=erppeek.Client(['-c', '$conf_file']);";
+    local python_cmd="import erppeek; cl=erppeek.Client(['-c', '$conf_file', '--logfile', '/dev/null']);";
     python_cmd="$python_cmd exit(int(not(cl.db.db_exist('$db_name'))));";
     
     if execu python -c "\"$python_cmd\""; then

--- a/lib/db.bash
+++ b/lib/db.bash
@@ -78,6 +78,7 @@ function odoo_db_dump {
     local db_dump_file=$2;
     local conf_file=$ODOO_CONF_FILE;
 
+    # determine 3-d and 4-th arguments (format and odoo_conf_file)
     if [ -f "$3" ]; then
         conf_file=$3;
     elif [ ! -z $3 ]; then

--- a/lib/db.bash
+++ b/lib/db.bash
@@ -24,7 +24,7 @@ function odoo_db_create {
     echov "Creating odoo database $db_name using conf file $conf_file";
 
     local python_cmd="import erppeek; cl=erppeek.Client(['-c', '$conf_file']);";
-    python_cmd="$python_cmd cl.db.create_database(cl._server.tools.config['admin_passwd'], '$db_name', True, 'en_US');"
+    python_cmd="$python_cmd cl.db.create_database(cl._server.tools.config['admin_passwd'], '$db_name', ${DB_DEMO:-True}, '${DB_LANG:-en_US}');"
 
     execu python -c "\"$python_cmd\"";
     

--- a/lib/default_config/coverage.cfg
+++ b/lib/default_config/coverage.cfg
@@ -1,0 +1,6 @@
+[run]
+omit = 
+    */__openerp__.py
+    .ropeproject/*
+parallel = on
+

--- a/lib/default_config/flake8.cfg
+++ b/lib/default_config/flake8.cfg
@@ -1,0 +1,14 @@
+[flake8]
+# Baased on: https://github.com/OCA/maintainer-quality-tools/tree/master/travis/cfg
+# E123,E133,E226,E241,E242 are ignored by default by pep8 and flake8
+# F811 is legal in odoo 8 when we implement 2 interfaces for a method
+ignore = E123,E133,E226,E241,E242,F811
+max-line-length = 79
+exclude =
+    .git,
+    __unported__,
+    __init__.py
+statistics = True
+show_source = True
+count = True
+format = ${cyan}%(path)s${reset}:${yellow_bold}%(row)d${reset}:${green_bold}%(col)d${reset}: ${red_bold}%(code)s${reset} %(text)s

--- a/lib/default_config/flake8.cfg
+++ b/lib/default_config/flake8.cfg
@@ -7,7 +7,8 @@ max-line-length = 79
 exclude =
     .git,
     __unported__,
-    __init__.py
+    __init__.py,
+    .ropeproject
 statistics = True
 show_source = True
 count = True

--- a/lib/default_config/pylint_odoo.cfg
+++ b/lib/default_config/pylint_odoo.cfg
@@ -1,0 +1,66 @@
+# Based on: https://github.com/OCA/maintainer-quality-tools/tree/master/travis/cfg
+[MASTER]
+profile=no
+ignore=CVS,.git,scenarios,.bzr
+persistent=yes
+cache-size=500
+load-plugins=pylint_odoo
+
+[MESSAGES CONTROL]
+disable=all
+# Enable message and code:
+#   anomalous-backslash-in-string - W1401
+#   assignment-from-none - W1111
+#   dangerous-default-value - W0102
+#   duplicate-key - W0109
+#   pointless-statement - W0104
+#   pointless-string-statement - W0105
+#   print-statement - E1601
+#   redundant-keyword-arg - E1124
+#   reimported - W0404
+#   relative-import - W0403
+#   return-in-init - E0101
+#   too-few-format-args - E1306
+#   unreachable - W0101
+
+enable=anomalous-backslash-in-string,
+    assignment-from-none,
+    dangerous-default-value,
+    duplicate-key,
+    missing-import-error,
+    missing-manifest-dependency,
+    pointless-statement,
+    pointless-string-statement,
+    print-statement,
+    redundant-keyword-arg,
+    reimported,
+    relative-import,
+    return-in-init,
+    too-few-format-args,
+    unreachable,
+    odoolint
+
+
+[REPORTS]
+msg-template={path}:{line}: [{msg_id}({symbol}), {obj}] {msg}
+output-format=colorized
+files-output=no
+reports=no
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+comment=no
+
+[FORMAT]
+indent-string='    '
+
+[SIMILARITIES]
+ignore-comments=yes
+ignore-docstrings=yes
+min-similarity-lines=8
+
+[MISCELLANEOUS]
+notes=TODO
+
+[IMPORTS]
+deprecated-modules=pdb,pudb,ipdb,openerp.osv
+
+

--- a/lib/fetch.bash
+++ b/lib/fetch.bash
@@ -299,10 +299,10 @@ function fetch_module {
     #        - warn and return
     #    - module absent in addons
     #        - clone and link
-    # - repo dir
-    #    - pull 
+    # - repo dir exists:
+    #    - repository is already clonned
 
-    # Clone or pull repository
+    # Clone
     if [ ! -d $REPO_PATH ]; then
         if [ ! -z $MODULE ] && [ -d "$ADDONS_DIR/$MODULE" ]; then
             echo "The module $MODULE already present in addons dir";
@@ -322,19 +322,6 @@ function fetch_module {
                 )
             fi
         fi
-    else
-        (
-            cd $REPO_PATH;
-            if [ -z $VERBOSE ]; then local verbose_opt="";
-            else local verbose_opt=" -q "; fi
-            if [ "$(git_get_branch_name)" == "$REPO_BRANCH" ]; then
-                    git pull $verbose_opt;
-            #else
-                #git fetch $verbose_opt;
-                #git stash $verbose_opt;  # TODO: seems to be not correct behavior. think about workaround
-                #git checkout $verbose_opt $REPO_BRANCH;
-            fi
-        )
     fi
 
     if [ -d $REPO_PATH ]; then

--- a/lib/fetch.bash
+++ b/lib/fetch.bash
@@ -412,14 +412,14 @@ function fetch_module {
             [ -z $VERBOSE ] && local git_clone_opt=" -q "
             if ! git clone $git_clone_opt $REPO_BRANCH_OPT $REPOSITORY $REPO_PATH; then
                 echo -e "${REDC}Cannot clone '$REPOSITORY to $REPO_PATH'!${NC}";
-            else
+            elif [ -z "$REPO_BRANCH_OPT" ]; then
                 # IF repo clonned successfuly, and not branch specified then
                 # try to checkout to ODOO_VERSION branch if it exists.
                 (
-                    [ -z "$REPO_BRANCH_OPT" ] && cd $REPO_PATH && \
+                    cd $REPO_PATH && \
                     [ "$(git_get_branch_name)" != "${ODOO_VERSION:-$ODOO_BRANCH}" ] && \
                     [ $(git branch --list -a "origin/${ODOO_VERSION:-$ODOO_BRANCH}") ] && \
-                    git checkout -q ${ODOO_VERSION:-$ODOO_BRANCH}
+                    git checkout -q ${ODOO_VERSION:-$ODOO_BRANCH} || true
                 )
             fi
         fi

--- a/lib/fetch.bash
+++ b/lib/fetch.bash
@@ -84,7 +84,19 @@ function fetch_pip_requirements {
     fi
 
     # Do pip install
-    execu pip install -r $pip_requirements;
+    #
+    # Here we set workdir to directory that conains requirements file,
+    # before running pip install, to allow usage of relative requirements.
+    # This is useful in case, when addon depends on python module,
+    # that is not on pip or github, but placed directly in addon directory,
+    # and should be installed via setup.py
+    #
+    # Example requirements.txt:
+    #
+    # -e ./lib/python-project
+    #
+    local req_dir=$(dirname $pip_requirements);
+    (cd $req_dir && execu pip install -r $pip_requirements);
 }
 
 # fetch_oca_requirements <filepath>

--- a/lib/fetch.bash
+++ b/lib/fetch.bash
@@ -371,10 +371,9 @@ function fetch_module {
             echo "The module $MODULE already present in addons dir";
             return 0;
         else
-            if [ -z $VERBOSE ]; then
-                git clone -q $REPO_BRANCH_OPT $REPOSITORY $REPO_PATH;
-            else
-                git clone $REPO_BRANCH_OPT $REPOSITORY $REPO_PATH;
+            [ -z $VERBOSE ] && local git_clone_opt=" -q "
+            if ! git clone $git_clone_opt $REPO_BRANCH_OPT $REPOSITORY $REPO_PATH; then
+                echo -e "${REDC}Cannot clone '$REPOSITORY to $REPO_PATH'!${NC}";
             fi
         fi
     else
@@ -384,10 +383,10 @@ function fetch_module {
             else local verbose_opt=" -q "; fi
             if [ "$(git_get_branch_name)" == "$REPO_BRANCH" ]; then
                     git pull $verbose_opt;
-            else
-                git fetch $verbose_opt;
-                git stash $verbose_opt;  # TODO: seems to be not correct behavior. think about workaround
-                git checkout $verbose_opt $REPO_BRANCH;
+            #else
+                #git fetch $verbose_opt;
+                #git stash $verbose_opt;  # TODO: seems to be not correct behavior. think about workaround
+                #git checkout $verbose_opt $REPO_BRANCH;
             fi
         )
     fi

--- a/lib/fetch.bash
+++ b/lib/fetch.bash
@@ -386,6 +386,11 @@ function fetch_module {
     REPO_NAME=${REPO_NAME:-$(get_repo_name $REPOSITORY)};
     local REPO_PATH=$REPOSITORIES_DIR/$REPO_NAME;
 
+    local recursion_key="fetch_module";
+    if ! recursion_protection_easy_check $recursion_key "${REPO_PATH}__${MODULE:-all}"; then
+        echo -e "${YELLOWC}WARN${NC}: fetch REPO__MODULE ${REPO_PATH}__${MODULE:-all} already had been processed. skipping...";
+        return 0
+    fi
     # Conditions:
     # - repo dir not exists and no module name specified
     #    - clone

--- a/lib/fetch.bash
+++ b/lib/fetch.bash
@@ -11,6 +11,7 @@ fi
 # Require libs
 ohelper_require 'git';
 ohelper_require 'recursion';
+ohelper_require 'addons';
 # ----------------------------------------------------------------------------------------
 
 set -e; # fail on errors
@@ -235,7 +236,7 @@ function link_module {
 
             # No module name specified, then all modules in repository should be linked
             for file in "$REPO_PATH"/*; do
-                if is_odoo_module $file; then
+                if is_odoo_module $file && addons_is_installable $file; then
                     link_module_impl $file $ADDONS_DIR/`basename $file` $force;
                     # recursivly link module
                 fi

--- a/lib/fetch.bash
+++ b/lib/fetch.bash
@@ -300,7 +300,9 @@ function fetch_module {
             ;;
             --oca)
                 REPOSITORY="https://github.com/OCA/$2";
-                REPO_BRANCH=${REPO_BRANCH:-$ODOO_BRANCH};  # Here we could use same branch as branch of odoo installed
+                # for backward compatability (if odoo version not defined,
+                # then use odoo branch
+                REPO_BRANCH=${REPO_BRANCH:-${ODOO_VERSION:-$ODOO_BRANCH}};
                 shift;
             ;;
             -m|--module)
@@ -351,7 +353,7 @@ function fetch_module {
         exit 2;
     fi
 
-    REPO_NAME=${REPO_NAME:-`get_repo_name $REPOSITORY`};
+    REPO_NAME=${REPO_NAME:-$(get_repo_name $REPOSITORY)};
     local REPO_PATH=$REPOSITORIES_DIR/$REPO_NAME;
 
     # Conditions:

--- a/lib/fetch.bash
+++ b/lib/fetch.bash
@@ -210,9 +210,14 @@ function link_module {
         shift
     done
 
-
     local REPO_PATH=$(readlink -f $1);
     local MODULE_NAME=$2
+
+    local recursion_key="link_module";
+    if ! recursion_protection_easy_check $recursion_key "${REPO_PATH}__${MODULE_NAME:-all}"; then
+        echo -e "${YELLOWC}WARN${NC}: REPO__MODULE ${REPO_PATH}__${MODULE_NAME:-all} already had been processed. skipping...";
+        return 0
+    fi
 
     echov "Linking module $1 [$2] ...";
 

--- a/lib/install.bash
+++ b/lib/install.bash
@@ -167,19 +167,14 @@ function install_virtual_env {
     fi
 }
 
-# install_python_prerequirements [install extra utils (1)]
+# install_python_prerequirements
 function install_python_prerequirements {
-    local install_extra_utils=${1:-$INSTALL_EXTRA_UTILS};
     # required to make odoo.py work correctly when setuptools too old
     execu easy_install --upgrade setuptools;
-    execu pip install --upgrade pip;  
+    execu pip install --upgrade pip erppeek setproctitle python-slugify watchdog;  
 
     if ! execu python -c 'import pychart'; then
         execu pip install http://download.gna.org/pychart/PyChart-1.39.tar.gz;
-    fi
-
-    if [ ! -z $install_extra_utils ]; then
-        execu pip install --upgrade erppeek setproctitle python-slugify watchdog;
     fi
 
     # Install PIL only for odoo versions that have no requirements txt (<8.0)

--- a/lib/install.bash
+++ b/lib/install.bash
@@ -239,12 +239,14 @@ function odoo_gevent_install_workaround_cleanup {
     fi
 }
 
+
+# odoo_run_setup_py [setup.py develop arguments]
 function odoo_run_setup_py {
     # Workaround for situation when setup does not install openerp-gevent script.
     odoo_gevent_install_workaround;
 
     # Install odoo
-    (cd $ODOO_PATH && execu python setup.py develop);
+    (cd $ODOO_PATH && execu python setup.py develop $@);
 
      
     # Workaround for situation when setup does not install openerp-gevent script.

--- a/lib/install.bash
+++ b/lib/install.bash
@@ -164,8 +164,9 @@ function install_system_prerequirements {
 
     # Install wkhtmltopdf
     if [ ! -f $DOWNLOADS_DIR/wkhtmltox.deb ]; then
-        wget -q http://download.gna.org/wkhtmltopdf/0.12/0.12.2.1/wkhtmltox-0.12.2.1_linux-trusty-amd64.deb -O $DOWNLOADS_DIR/wkhtmltox.deb
-        with_sudo dpkg --force-depends -i /tmp/wkhtmltox.deb  # install ignoring dependencies
+        wget -q http://download.gna.org/wkhtmltopdf/0.12/0.12.2.1/wkhtmltox-0.12.2.1_linux-trusty-amd64.deb \
+             -O $DOWNLOADS_DIR/wkhtmltox.deb
+        with_sudo dpkg --force-depends -i $DOWNLOADS_DIR/wkhtmltox.deb  # install ignoring dependencies
         with_sudo apt-get -f install $opt_apt_always_yes;   # fix broken packages
     fi
 

--- a/lib/install.bash
+++ b/lib/install.bash
@@ -257,7 +257,7 @@ function odoo_run_setup_py {
 function install_entry_point {
     local usage="Usage:
 
-        $SCRIPT_NAME install sys-deps <odoo-version>       - list git repositories
+        $SCRIPT_NAME install sys-deps [-y] <odoo-version>  - list git repositories
         $SCRIPT_NAME install postgres [user] [password]    - install postgres.
                                                              and if user/password specified, create it
         $SCRIPT_NAME install --help                        - show this help message
@@ -275,6 +275,10 @@ function install_entry_point {
         case $key in
             sys-deps)
                 shift;
+                if [ "$1" == "-y" ]; then
+                    ALWAYS_ANSWER_YES=1;
+                    shift;
+                fi
                 install_sys_deps_for_odoo_version "$@";
                 exit 0;
             ;;

--- a/lib/install.bash
+++ b/lib/install.bash
@@ -165,7 +165,7 @@ function install_and_configure_postgresql {
 }
 
 
-# install_system_prerequirements [install extra utils (1)]
+# install_system_prerequirements
 function install_system_prerequirements {
     if [ ! -z $ALWAYS_ANSWER_YES ]; then
         local opt_apt_always_yes="-y";

--- a/lib/install.bash
+++ b/lib/install.bash
@@ -155,7 +155,7 @@ function install_system_prerequirements {
 
     echo "Installing system preprequirements...";
     install_sys_deps_internal git wget python-setuptools perl g++ \
-        libpq-dev python-dev expect-dev
+        libpq-dev python-dev expect-dev libevent-dev
 
     install_wkhtmltopdf;
 
@@ -255,7 +255,10 @@ function odoo_run_setup_py {
 
     # Install dependencies via pip (it is faster if they are cached)
     if [ -f "$ODOO_PATH/requirements.txt" ]; then
-        execu pip install -r $ODOO_PATH/requirements.txt;
+        if ! execu pip install -r $ODOO_PATH/requirements.txt; then
+            echo -e "${YELLOWC}WARNING:${NC} error while installing requirements via pip. " \
+                "This may be caused by error when building gevent on ubuntu.";
+        fi
     fi
 
     # Install odoo

--- a/lib/install.bash
+++ b/lib/install.bash
@@ -23,6 +23,7 @@ function install_preconfigure_env {
     DB_USER=${ODOO_DBUSER:-odoo};
     DB_PASSWORD=${ODOO_DBPASSWORD:-odoo};
     DB_HOST=${ODOO_DBHOST:-localhost};
+    DB_PORT=${ODOO_DBPORT:-5432};
 }
 
 # create directory tree for project
@@ -71,7 +72,7 @@ function install_sys_deps_internal {
     if [ ! -z $ALWAYS_ANSWER_YES ]; then
         local opt_apt_always_yes="-y";
     fi
-    sudo apt-get install $opt_apt_always_yes "$@";
+    with_sudo apt-get install $opt_apt_always_yes "$@";
 }
 
 # Get dependencies from odoo's debian/control file
@@ -133,22 +134,22 @@ function install_system_prerequirements {
     fi
 
     echo "Updating package list..."
-    sudo apt-get update || true;
+    with_sudo apt-get update || true;
 
     echo "Installing system preprequirements...";
     local to_install="git wget python-setuptools perl g++ libpq-dev python-dev";
     if [ ! -z $install_extra_utils ]; then
         to_install="$to_install expect-dev";
     fi;
-    sudo apt-get install $opt_apt_always_yes $to_install;
+    with_sudo apt-get install $opt_apt_always_yes $to_install;
 
     # Install wkhtmltopdf
     wget http://download.gna.org/wkhtmltopdf/0.12/0.12.2.1/wkhtmltox-0.12.2.1_linux-trusty-amd64.deb -O /tmp/wkhtmltox.deb
-    sudo dpkg --force-depends -i /tmp/wkhtmltox.deb  # install ignoring dependencies
-    sudo apt-get -f install $opt_apt_always_yes;   # fix broken packages
+    with_sudo dpkg --force-depends -i /tmp/wkhtmltox.deb  # install ignoring dependencies
+    with_sudo apt-get -f install $opt_apt_always_yes;   # fix broken packages
 
-    sudo easy_install pip;
-    sudo pip install --upgrade pip virtualenv;
+    with_sudo easy_install pip;
+    with_sudo pip install --upgrade pip virtualenv;
 }
 
 

--- a/lib/install.bash
+++ b/lib/install.bash
@@ -176,7 +176,9 @@ function install_system_prerequirements {
 
     echo "Installing system preprequirements...";
     install_sys_deps_internal git wget python-setuptools perl g++ \
-        libpq-dev python-dev expect-dev libevent-dev
+        libpq-dev python-dev expect-dev libevent-dev libjpeg-dev \
+        libfreetype6-dev zlib1g-dev libxml2-dev libxslt-dev \
+        libsasl2-dev libldap2-dev libssl-dev;
 
     if ! install_wkhtmltopdf; then
         echo "Cannot install wkhtmltopdf!!! Skipping...";
@@ -280,7 +282,7 @@ function odoo_run_setup_py {
     if [ -f "$ODOO_PATH/requirements.txt" ]; then
         if ! execu pip install -r $ODOO_PATH/requirements.txt; then
             echo -e "${YELLOWC}WARNING:${NC} error while installing requirements via pip. " \
-                "This may be caused by error when building gevent on ubuntu.";
+                    "This may be caused by compilation error when building one of python packages on ubuntu.";
         fi
     fi
 

--- a/lib/install.bash
+++ b/lib/install.bash
@@ -178,7 +178,9 @@ function install_system_prerequirements {
     install_sys_deps_internal git wget python-setuptools perl g++ \
         libpq-dev python-dev expect-dev libevent-dev
 
-    install_wkhtmltopdf;
+    if ! install_wkhtmltopdf; then
+        echo "Cannot install wkhtmltopdf!!! Skipping...";
+    fi
 
     with_sudo easy_install pip;
     with_sudo pip install --upgrade pip virtualenv;

--- a/lib/install.bash
+++ b/lib/install.bash
@@ -188,14 +188,19 @@ function install_python_prerequirements {
 }
 
 # Generate configuration file fo odoo
-# this function looks into ODOO_CONF_OPTIONS anvironment variable,
+# this function looks into ODOO_CONF_OPTIONS environment variable,
 # which should be associative array with options to be written to file
 # install_generate_odoo_conf <file_path>
 function install_generate_odoo_conf {
     local conf_file=$1;
 
     # default addonspath
-    local addons_path="$ODOO_PATH/openerp/addons,$ODOO_PATH/addons,$ADDONS_DIR";
+    local addons_path="$ODOO_PATH/addons,$ADDONS_DIR";
+    if [ -e "$ODOO_PATH/odoo/addons" ]; then
+        addons_path="$ODOO_PATH/odoo/addons,$addons_path";
+    elif [ -e "$ODOO_PATH/openerp/addons" ]; then
+        addons_path="$ODOO_PATH/openerp/addons,$addons_path";
+    fi
 
     # default values
     ODOO_CONF_OPTIONS[addons_path]="${ODOO_CONF_OPTIONS['addons_path']:-$addons_path}";

--- a/lib/install.bash
+++ b/lib/install.bash
@@ -55,6 +55,27 @@ function install_clone_odoo {
 
 }
 
+# install_download_odoo [path [branch [repo]]]
+function install_download_odoo {
+    local odoo_path=${1:-$ODOO_PATH};
+    local odoo_branch=${2:-$ODOO_BRANCH};
+    local odoo_repo=${3:-${ODOO_REPO:-https://github.com/odoo/odoo.git}};
+
+    local odoo_archive=/tmp/odoo.$ODOO_BRANCH.tar.gz
+    if [ -f $odoo_archive ]; then
+        rm $odoo_archive;
+    fi
+
+    if [[ $ODOO_REPO == "https://github.com"* ]]; then
+        local repo=${odoo_repo%.git};
+        local repo_base=$(basename $repo);
+        wget -O $odoo_archive $repo/archive/$ODOO_BRANCH.tar.gz;
+        tar -zxf $odoo_archive;
+        mv ${repo_base}-${ODOO_BRANCH} $ODOO_PATH;
+        rm $odoo_archive;
+    fi
+}
+
 
 # install_wkhtmltopdf
 function install_wkhtmltopdf {
@@ -254,12 +275,12 @@ function odoo_run_setup_py {
     odoo_gevent_install_workaround;
 
     # Install dependencies via pip (it is faster if they are cached)
-    #if [ -f "$ODOO_PATH/requirements.txt" ]; then
-        #if ! execu pip install -r $ODOO_PATH/requirements.txt; then
-            #echo -e "${YELLOWC}WARNING:${NC} error while installing requirements via pip. " \
-                #"This may be caused by error when building gevent on ubuntu.";
-        #fi
-    #fi
+    if [ -f "$ODOO_PATH/requirements.txt" ]; then
+        if ! execu pip install -r $ODOO_PATH/requirements.txt; then
+            echo -e "${YELLOWC}WARNING:${NC} error while installing requirements via pip. " \
+                "This may be caused by error when building gevent on ubuntu.";
+        fi
+    fi
 
     # Install odoo
     (cd $ODOO_PATH && execu python setup.py develop $@);

--- a/lib/install.bash
+++ b/lib/install.bash
@@ -173,7 +173,7 @@ function install_python_prerequirements {
     execu easy_install --upgrade setuptools;
     execu pip install --upgrade pip erppeek setproctitle python-slugify watchdog;  
 
-    if ! execu python -c 'import pychart'; then
+    if ! execu "python -c 'import pychart'"; then
         execu pip install http://download.gna.org/pychart/PyChart-1.39.tar.gz;
     fi
 

--- a/lib/install.bash
+++ b/lib/install.bash
@@ -132,14 +132,14 @@ function install_and_configure_postgresql {
     # Check if postgres is installed on this machine. If not, install it
     if ! postgres_is_installed; then
         postgres_install_postgresql;
-        echov "Postgres installed";
+        echo -e "${GREENC}Postgres installed${NC}";
     else
-        echov "It seems that postgresql is already installed, so not installing it, just configuring...";
+        echo -e "${YELLOWC}It seems that postgresql is already installed, so not installing it, just configuring...${NC}";
     fi
 
     if [ ! -z $db_user ] && [ ! -z $db_password ]; then
         postgres_user_create $db_user $db_password;
-        echov "Postgres user $db_user created";
+        echo -e "${GREENC}Postgres user $db_user created${NC}";
     fi
 }
 
@@ -254,12 +254,12 @@ function odoo_run_setup_py {
     odoo_gevent_install_workaround;
 
     # Install dependencies via pip (it is faster if they are cached)
-    if [ -f "$ODOO_PATH/requirements.txt" ]; then
-        if ! execu pip install -r $ODOO_PATH/requirements.txt; then
-            echo -e "${YELLOWC}WARNING:${NC} error while installing requirements via pip. " \
-                "This may be caused by error when building gevent on ubuntu.";
-        fi
-    fi
+    #if [ -f "$ODOO_PATH/requirements.txt" ]; then
+        #if ! execu pip install -r $ODOO_PATH/requirements.txt; then
+            #echo -e "${YELLOWC}WARNING:${NC} error while installing requirements via pip. " \
+                #"This may be caused by error when building gevent on ubuntu.";
+        #fi
+    #fi
 
     # Install odoo
     (cd $ODOO_PATH && execu python setup.py develop $@);

--- a/lib/link.bash
+++ b/lib/link.bash
@@ -1,0 +1,144 @@
+if [ -z $ODOO_HELPER_LIB ]; then
+    echo "Odoo-helper-scripts seems not been installed correctly.";
+    echo "Reinstall it (see Readme on https://github.com/katyukha/odoo-helper-scripts/)";
+    exit 1;
+fi
+
+if [ -z $ODOO_HELPER_COMMON_IMPORTED ]; then
+    source $ODOO_HELPER_LIB/common.bash;
+fi
+
+# Require libs
+ohelper_require 'git';
+ohelper_require 'recursion';
+ohelper_require 'addons';
+ohelper_require 'fetch';
+# ----------------------------------------------------------------------------------------
+
+set -e; # fail on errors
+
+# Define veriables
+REQUIREMENTS_FILE_NAME="odoo_requirements.txt";
+PIP_REQUIREMENTS_FILE_NAME="requirements.txt";
+OCA_REQUIREMENTS_FILE_NAME="oca_dependencies.txt";
+
+
+# link_module_impl <source_path> <dest_path> <force: on|off>
+function link_module_impl {
+    local SOURCE=`readlink -f $1`;
+    local DEST="$2";
+    local force=$3;
+
+    if [ $force == "on" ] && ([ -e $DEST ] || [ -L $DEST ]); then
+        echov "Rewriting module $DEST...";
+        rm -rf $DEST;
+    fi
+
+    if [ ! -d $DEST ]; then
+        if [ -z $USE_COPY ]; then
+            if [ -h $DEST ] && [ ! -e $DEST ]; then
+                # If it is broken link, remove it
+                rm $DEST;
+            fi
+            ln -s $SOURCE $DEST ;
+        else
+            cp -r $SOURCE $DEST;
+        fi
+    else
+        echov "Module $SOURCE already linked to $DEST";
+    fi
+    fetch_requirements $DEST;
+    fetch_pip_requirements $DEST/$PIP_REQUIREMENTS_FILE_NAME;
+    fetch_oca_requirements $DEST/$OCA_REQUIREMENTS_FILE_NAME;
+}
+
+# link_module <force: on|off> <repo_path> [<module_name>]
+function link_module {
+    local force=$1;
+    local REPO_PATH=$2;
+    local MODULE_NAME=$3
+
+    if [ -z $REPO_PATH ]; then
+        echo -e "${REDC}Bad repo path fot link: $REPO_PATH${NC}";
+        return 2;
+    fi
+
+    REPO_PATH=$(readlink -f $2);
+
+    local recursion_key="link_module";
+    if ! recursion_protection_easy_check $recursion_key "${REPO_PATH}__${MODULE_NAME:-all}"; then
+        echo -e "${YELLOWC}WARN${NC}: REPO__MODULE ${REPO_PATH}__${MODULE_NAME:-all} already had been processed. skipping...";
+        return 0
+    fi
+
+    echov "Linking module $REPO_PATH [$MODULE_NAME] ...";
+
+    # Guess repository type
+    if is_odoo_module $REPO_PATH; then
+        # single module repo
+        link_module_impl $REPO_PATH $ADDONS_DIR/${MODULE_NAME:-`basename $REPO_PATH`} $force;
+    else
+        # multi module repo
+        if [ -z $MODULE_NAME ]; then
+            # Check for requirements files in repository root dir
+            fetch_requirements $REPO_PATH;
+            fetch_pip_requirements $REPO_PATH/$PIP_REQUIREMENTS_FILE_NAME;
+            fetch_oca_requirements $REPO_PATH/$OCA_REQUIREMENTS_FILE_NAME;
+
+            # No module name specified, then all modules in repository should be linked
+            for file in "$REPO_PATH"/*; do
+                if is_odoo_module $file && addons_is_installable $file; then
+                    # link module
+                    link_module_impl $file $ADDONS_DIR/`basename $file` $force;
+                elif [ -d $file ] && ! is_odoo_module $file && [ $(basename $file) != 'setup' ]; then
+                    # if it is directory but not odoo module, recursively look for addons there
+                    link_module $force $file;
+                fi
+            done
+        else
+            # Module name specified, then only single module should be linked
+            link_module_impl $REPO_PATH/$MODULE_NAME $ADDONS_DIR/$MODULE_NAME $force;
+        fi
+    fi
+}
+
+
+function link_command {
+    local usage="
+    Usage: 
+
+        $SCRIPT_NAME link [-f|--force] <repo_path> [<module_name>]
+    ";
+
+    local force=off;
+
+    # Parse command line options and run commands
+    if [[ $# -lt 1 ]]; then
+        echo "No options supplied $#: $@";
+        echo "";
+        echo "$usage";
+        exit 0;
+    fi
+
+    # Process all args that starts with '-' (ie. options)
+    while [[ $1 == -* ]]
+    do
+        key="$1";
+        case $key in
+            -h|--help)
+                echo "$usage";
+                exit 0;
+            ;;
+            -f|--force)
+                force=on;
+            ;;
+            *)
+                echo "Unknown option $key";
+                exit 1;
+            ;;
+        esac
+        shift
+    done
+
+    link_module $force "$@"
+}

--- a/lib/odoo.bash
+++ b/lib/odoo.bash
@@ -69,6 +69,7 @@ function odoo_update_sources_archive {
 
     echo -e "${LBLUEC}Downloading new sources archive...${NC}"
     local ODOO_ARCHIVE=$DOWNLOADS_DIR/odoo.$ODOO_BRANCH.$FILE_SUFFIX.tar.gz
+    # TODO: use odoo-repo variable here
     wget $wget_opt -O $ODOO_ARCHIVE https://github.com/odoo/odoo/archive/$ODOO_BRANCH.tar.gz;
     rm -r $ODOO_PATH;
     (cd $DOWNLOADS_DIR && tar -zxf $ODOO_ARCHIVE && mv odoo-$ODOO_BRANCH $ODOO_PATH);

--- a/lib/postgres.bash
+++ b/lib/postgres.bash
@@ -57,7 +57,7 @@ function postgres_user_create {
     local user_password="$2";
 
     if ! postgres_user_exists $user_name; then
-        sudo -u postgres -H psql -c "CREATE USER $user_name WITH CREATEDB PASSWORD '$user_password';"
+        sudo -u postgres -H psql -c "CREATE USER \"$user_name\" WITH CREATEDB PASSWORD '$user_password';"
         echov "Postgresql user $user_name was created for this Odoo instance";
     else
         echo -e "${YELLOWC}There are $user_name already exists in postgres server${NC}";

--- a/lib/recursion.bash
+++ b/lib/recursion.bash
@@ -1,0 +1,87 @@
+# Recursion protection utils
+
+if [ -z $ODOO_HELPER_LIB ]; then
+    echo "Odoo-helper-scripts seems not been installed correctly.";
+    echo "Reinstall it (see Readme on https://github.com/katyukha/odoo-helper-scripts/)";
+    exit 1;
+fi
+
+if [ -z $ODOO_HELPER_COMMON_IMPORTED ]; then
+    source $ODOO_HELPER_LIB/common.bash;
+fi
+
+# -----------------------------------------------------------------------------
+
+set -e; # fail on errors
+
+
+# get obj_name for key
+function __recursion_get_obj_name {
+    echo "__RECURSION_PROTECTION__OBJ_${1}__"
+}
+
+
+# Initialize recursion protection for key
+# recursion_protection_init <key>
+function recursion_protection_init {
+    local obj_name=$(__recursion_get_obj_name $1);
+    if [ -z "${!obj_name:-''}" ]; then
+        return 1;
+    fi
+
+    declare -gA "$obj_name";
+    return 0;
+}
+
+# Check recursion protection for key,value
+# This function check if value for key already checked.
+# If not them mark it as checked.
+# If passed value already was checked by this function,
+# then return non-zero exit code. If passed value was not checked before,
+# then return zero exit code.
+#
+# recursion_protection_check <key> <value>
+function recursion_protection_check {
+    # Exit with 2 code if no key and value specified
+    if [ -z $1 ] || [ -z $2 ]; then
+        return 2;
+    fi
+
+    local key=$1;
+    local value=$(echo "$2" | sed -r "s/[^A-Za-z0-9]/_/g");
+
+    local obj_name=$(__recursion_get_obj_name $key);
+    local res="$(eval echo \"\${${obj_name}[$value]}\")"
+
+    #if [ "$key" == "fetch_oca_requirements" ]; then
+        #echo "X: $key; Y: $value; Z: $res";
+    #fi
+    if [ -z "${res:-}" ]; then
+        eval "${obj_name}['$value']=1";
+        return 0;
+    else
+        return 1;
+    fi
+}
+
+
+# Close recursion protection for a key
+#
+# recursion_protection_close <key>
+function recursion_protection_close {
+    unset $(__recursion_get_obj_name $1);
+}
+
+
+# Simplified call to recursion protection
+#
+# recursion_protection_easy_check <key> <value>
+function recursion_protection_easy_check {
+    recursion_protection_init $1 || true;
+
+    if recursion_protection_check $1 $2; then
+        return 0;
+    else
+        return 1;
+    fi
+}

--- a/lib/server.bash
+++ b/lib/server.bash
@@ -23,7 +23,7 @@ set -e; # fail on errors
 #  which should be placed in project config)
 # Now it simply returns openerp-server
 function get_server_script {
-    check_command odoo.py openerp-server openerp-server.py;
+    check_command odoo odoo.py openerp-server openerp-server.py;
 }
 
 # Function to check server run status;

--- a/lib/server.bash
+++ b/lib/server.bash
@@ -51,6 +51,7 @@ function run_server_impl {
     local SERVER=`get_server_script`;
     echo -e "${LBLUEC}Running server${NC}: $SERVER $@";
     export OPENERP_SERVER=$ODOO_CONF_FILE;
+    export ODOO_RC=$ODOO_CONF_FILE;  # for odoo 10.0+
     if [ ! -z $SERVER_RUN_USER ]; then
         local sudo_opt="sudo -u $SERVER_RUN_USER -H -E";
         echov "Using server run opt: $sudo_opt";
@@ -58,6 +59,7 @@ function run_server_impl {
 
     execu "$sudo_opt $SERVER $@";
     unset OPENERP_SERVER;
+    unset ODOO_RC;
 }
 
 # server_run <arg1> .. <argN>

--- a/lib/server.bash
+++ b/lib/server.bash
@@ -117,8 +117,8 @@ function server_stop {
                 echo "Cannot kill process.";
             fi
         else
-            echo "Server seems not to be running!"
-            echo "Or PID file $ODOO_PID_FILE was removed";
+            echo -e "${YELLOWC}Server seems not to be running!${NC}"
+            echo -e "${YELLOWC}Or PID file $ODOO_PID_FILE was removed${NC}";
         fi
     fi
 

--- a/lib/system.bash
+++ b/lib/system.bash
@@ -1,0 +1,88 @@
+if [ -z $ODOO_HELPER_LIB ]; then
+    echo "Odoo-helper-scripts seems not been installed correctly.";
+    echo "Reinstall it (see Readme on https://github.com/katyukha/odoo-helper-scripts/)";
+    exit 1;
+fi
+
+if [ -z $ODOO_HELPER_COMMON_IMPORTED ]; then
+    source $ODOO_HELPER_LIB/common.bash;
+fi
+
+# ----------------------------------------------------------------------------------------
+#ohelper_require "postgres";
+
+
+set -e; # fail on errors
+
+# update odoo-helper-scripts
+function system_update_odoo_helper_scripts {
+    local scripts_branch=$1;
+
+    # update
+    local cdir=$(pwd);
+    cd $ODOO_HELPER_ROOT;
+    if [ -z $scripts_branch ]; then
+        git pull;
+    else
+        git fetch -q origin;
+        if ! git checkout -q origin/$scripts_branch; then
+            git checkout -q $scripts_branch;
+        fi
+    fi
+
+    # update odoo-helper bin links
+    local base_path=$(dirname $ODOO_HELPER_ROOT);
+    for oh_cmd in $ODOO_HELPER_BIN/*; do
+        if ! command -v $(basename $oh_cmd) >/dev/null 2>&1; then
+            if [ "$base_path" == /opt* ]; then
+                with_sudo ln -s $oh_cmd /usr/local/bin/;
+            elif [ "$base_path" == $HOME/* ]; then
+                ln -s $oh_cmd $HOME/bin;
+            fi
+        fi
+    done
+    cd $cdir;
+}
+
+
+# system entry point
+function system_entry_point {
+    local usage="Usage:
+
+        $SCRIPT_NAME system update [branch]      - update odoo-helper-scripts (to specified branch / commit)
+        $SCRIPT_NAME system lib-path <lib name>  - print path to lib with specified name
+        $SCRIPT_NAME system --help              - show this help message
+
+    ";
+
+    if [[ $# -lt 1 ]]; then
+        echo "$usage";
+        exit 0;
+    fi
+
+    while [[ $# -gt 0 ]]
+    do
+        local key="$1";
+        case $key in
+            update)
+                shift;
+                system_update_odoo_helper_scripts "$@";
+                exit 0;
+            ;;
+            lib-path)
+                shift;
+                oh_get_lib_path "$@"
+                exit 0;
+            ;;
+            -h|--help|help)
+                echo "$usage";
+                exit 0;
+            ;;
+            *)
+                echo "Unknown option / command $key";
+                exit 1;
+            ;;
+        esac
+        shift
+    done
+}

--- a/lib/test.bash
+++ b/lib/test.bash
@@ -69,7 +69,12 @@ function test_run_server {
 
     # enable test coverage
     if [ $with_coverage -eq 1 ]; then
-        execu "coverage run $(execv command -v $SERVER) --stop-after-init $@";
+        if [ -z $COVERAGE_INCLUDE ]; then
+            local COVERAGE_INCLUDE="$(pwd)/*";
+        fi
+        execu "coverage run --rcfile=$ODOO_HELPER_LIB/default_config/coverage.cfg \
+            --include='$COVERAGE_INCLUDE' $(execv command -v $SERVER) \
+            --stop-after-init $@";
     else
         execu "$SERVER --stop-after-init $@";
     fi
@@ -245,7 +250,7 @@ function test_run_flake8 {
             res=1;
         fi
     done
-    return res;
+    return $res;
 }
 
 # Run pylint tests for modules

--- a/lib/test.bash
+++ b/lib/test.bash
@@ -242,20 +242,18 @@ function test_find_modules_in_directories {
 }
 
 # Run flake8 for modules
-# test_run_flake8 <module1 path> [module2 path] .. [module n path]
+# test_run_flake8 [flake8 options] <module1 path> [module2 path] .. [module n path]
 function test_run_flake8 {
     local res=0;
-    for addon_path in $@; do
-        if ! execu flake8 --config="$ODOO_HELPER_LIB/default_config/flake8.cfg" $addon_path; then
-            res=1;
-        fi
-    done
+    if ! execu flake8 --config="$ODOO_HELPER_LIB/default_config/flake8.cfg" $@; then
+        res=1;
+    fi
     return $res;
 }
 
 # Run pylint tests for modules
-# test_run_flake8 <module1 path> [module2 path] .. [module n path]
-# test_run_flake8 [--disable=E111,E222,...] <module1 path> [module2 path] .. [module n path]
+# test_run_pylint <module1 path> [module2 path] .. [module n path]
+# test_run_pylint [--disable=E111,E222,...] <module1 path> [module2 path] .. [module n path]
 function test_run_pylint {
     if [[ "$1" =~ ^--disable=([a-zA-Z0-9,-]*) ]]; then
         local pylint_disable_opt=$1;

--- a/lib/test.bash
+++ b/lib/test.bash
@@ -118,11 +118,10 @@ function test_run_tests_for_modules {
     local test_log_file=$3;
     shift; shift; shift;
 
-    for module in $@; do
-        echo -e "${BLUEC}Testing module $module...${NC}";
-        test_module_impl $with_coverage $module --database $test_db_name \
-            2>&1 | tee -a $test_log_file;
-    done
+    local modules=$(join_by , $@);
+    echo -e "${BLUEC}Testing modules $modules...${NC}";
+    test_module_impl $with_coverage $modules --database $test_db_name \
+        2>&1 | tee -a $test_log_file;
 }
 
 
@@ -225,6 +224,10 @@ function test_run_tests {
 # test_find_modules_in_directories <dir1> [dir2] ...
 # echoes list of modules found in specified directories
 function test_find_modules_in_directories {
+    # TODO: sort addons in correct order to avoid duble test runs
+    #       in cases when addon that is tested first depends on other,
+    #       which is tested next, but when it is tested, then all dependent
+    #       addons will be also tested
     for directory in $@; do
         # skip non directories
         for addon_path in $(addons_list_in_directory $directory); do

--- a/lib/test.bash
+++ b/lib/test.bash
@@ -235,8 +235,8 @@ function test_find_modules_in_directories {
     #       addons will be also tested
     for directory in $@; do
         # skip non directories
-        for addon_path in $(addons_list_in_directory $directory); do
-            echo -n " $(basename $addon_path)";
+        for addon in $(addons_list_in_directory_by_name $directory); do
+            echo -n " $addon";
         done
     done
 }

--- a/lib/test.bash
+++ b/lib/test.bash
@@ -221,24 +221,41 @@ function test_run_tests {
     fi
 }
 
+
+# test_find_modules_in_directories <dir1> [dir2] ...
+# echoes list of modules found in specified directories
+function test_find_modules_in_directories {
+    for directory in $@; do
+        # skip non directories
+        for addon_path in $(addons_list_in_directory $directory); do
+            echo -n " $(basename $addon_path)";
+        done
+    done
+}
+
 # test_module [--create-test-db] -m <module_name>
 # test_module [--tmp-dirs] [--create-test-db] -m <module name> -m <module name>
+# test_module [--tmp-dirs] [--create-test-db] -d <dir with addons to test>
 function test_module {
     local create_test_db=0;
     local fail_on_warn=0;
     local with_coverage=0;
     local modules="";
+    local directories="";
     local usage="
     Usage 
 
-        $SCRIPT_NAME test_module [options] [-m <module_name>] [-m <module name>] ...
+        $SCRIPT_NAME test [options] [-m <module_name>] [-m <module name>] ...
+        $SCRIPT_NAME test [options] [-d <dir with addons to test>]
 
     Options:
         --create-test-db    - Creates temporary database to run tests in
         --fail-on-warn      - if this option passed, then tests will fail even on warnings
         --tmp-dirs          - use temporary dirs for test related downloads and addons
         --no-rm-tmp-dirs    - not remove temporary directories that was created for this test
-        --coverage          - calculate code coverage
+        --coverage          - calculate code coverage (use python's *coverage* util)
+        -m|--module         - specify module to test
+        -d|--directory      - specify directory with modules to test
     ";
 
     # Parse command line options and run commands
@@ -267,6 +284,10 @@ function test_module {
             ;;
             -m|--module)
                 modules="$modules $2";  # add module to module list
+                shift;
+            ;;
+            -d|--directory)
+                modules="$modules $(test_find_modules_in_directories $2)";
                 shift;
             ;;
             --tmp-dirs)

--- a/lib/test.bash
+++ b/lib/test.bash
@@ -18,7 +18,6 @@ ohelper_require odoo;
 set -e; # fail on errors
 
 
-
 # create_tmp_dirs
 function create_tmp_dirs {
     TMP_ROOT_DIR="/tmp/odoo-tmp-`random_string 16`";
@@ -60,6 +59,16 @@ function remove_tmp_dirs {
     OLD_ODOO_TEST_CONF_FILE=$ODOO_TEST_CONF_FILE;
 }
 
+
+# test_run_server [options]
+function test_run_server {
+    local SERVER=`get_server_script`;
+    echo -e "${LBLUEC}Running server [${YELLOWC}test${LBLUEC}]${NC}: $SERVER $@";
+    export OPENERP_SERVER=$ODOO_TEST_CONF_FILE;
+    execu "$SERVER --stop-after-init --no-xmlrpc $@";
+    unset OPENERP_SERVER;
+}
+
 # test_module_impl <module> [extra_options]
 # example: test_module_impl base -d test1
 function test_module_impl {
@@ -68,150 +77,49 @@ function test_module_impl {
 
     set +e; # do not fail on errors
     # Install module
-    run_server_impl -c $ODOO_TEST_CONF_FILE --init=$module --log-level=warn --stop-after-init \
-        --no-xmlrpc "$@";
+    test_run_server --init=$module --log-level=warn "$@";
     # Test module
-    run_server_impl -c $ODOO_TEST_CONF_FILE --update=$module --log-level=test --test-enable --stop-after-init \
-        --no-xmlrpc --workers=0 "$@";
+    test_run_server --update=$module --log-level=test --test-enable --workers=0 "$@";
     set -e; # Fail on any error
 }
 
+# Get database name or create new one. Prints database name
+# test_get_or_create_db    # get db
+# test_get_or_create_db 1  # create new db
+function test_get_or_create_db {
+    local create_test_db=$1;
 
-# test_module [--create-test-db] -m <module_name>
-# test_module [--tmp-dirs] [--create-test-db] -m <module name> -m <module name>
-function test_module {
-    local modules="";
-    local cs_modules="";
-    local link_module_args="";
-    local test_log_file="${LOG_DIR:-.}/odoo.test.log";
-    local odoo_extra_options="";
-    local usage="
-    Usage 
-
-        $SCRIPT_NAME test_module [options] [-m <module_name>] [-m <module name>] ...
-
-    Options:
-        --create-test-db    - Creates temporary database to run tests in
-        --remove-log-file   - If set, then log file will be removed after tests finished
-        --link <repo>:[module_name]
-        --tmp-dirs          - use temporary dirs for test related downloads and addons
-        --no-rm-tmp-dirs    - not remove temporary directories that was created for this test
-        --no-tee            - this option disable duplication of output to log file.
-                              it is implemented as workaroud of bug, when chaining 'tee' command
-                              to openerp-server removes all colors of output.
-        --reinit-base       - this option adds 'base' module to init list. this is way to reload module list in existing database
-        --fail-on-warn      - if this option passed, then tests will fail even on warnings
-    ";
-
-    # Parse command line options and run commands
-    if [[ $# -lt 1 ]]; then
-        echo "No options/commands supplied $#: $@";
-        echo "$usage";
-        exit 0;
-    fi
-
-    while [[ $# -gt 0 ]]
-    do
-        key="$1";
-        case $key in
-            -h|--help|help)
-                echo "$usage";
-                exit 0;
-            ;;
-            --create-test-db)
-                local create_test_db=1;
-            ;;
-            --remove-log-file)
-                local remove_log_file=1;
-            ;;
-            --reinit-base)
-                local reinit_base=1;
-            ;;
-            --fail-on-warn)
-                local fail_on_warn=1;
-            ;;
-            -m|--module)
-                modules="$modules $2";  # add module to module list
-                shift;
-            ;;
-            --link)
-                link_module_args=$link_module_args$'\n'$2;
-                shift;
-            ;;
-            --tmp-dirs)
-                local tmp_dirs=1
-            ;;
-            --no-rm-tmp-dirs)
-                local not_remove_tmp_dirs=1;
-            ;;
-            --no-tee)
-                local no_tee=1;
-            ;;
-            *)
-                echo "Unknown option: $key";
-                exit 1;
-            ;;
-        esac;
-        shift;
-    done;
-
-    if [ ! -z $tmp_dirs ]; then
-        create_tmp_dirs;
-    fi
-
-    # Parse --link args
-    if [ ! -z "$link_module_args" ]; then
-        for lm_arg in $link_module_args; do
-            local lm_arg_x=`echo $lm_arg | tr ':' ' '`;
-            link_module $lm_arg_x;
-        done
-    fi
-
-    # Create new test database if required
-    if [ ! -z $create_test_db ]; then
+    if [ $create_test_db -eq 1 ]; then
         local test_db_name=`random_string 24`;
-        test_log_file="${LOG_DIR:-.}/odoo.test.db.$test_db_name.log";
-        echo -e "Creating test database: ${YELLOWC}$test_db_name${NC}";
-        odoo_db_create $test_db_name $ODOO_TEST_CONF_FILE;
-        echov "Test database created successfully";
-        odoo_extra_options="$odoo_extra_options -d $test_db_name";
+        odoo_db_create $test_db_name $ODOO_TEST_CONF_FILE 1&>2;
     else
         # name of test database expected to be defined in ODOO_TEST_CONF_FILE
         local test_db_name="$(odoo_get_conf_val db_name $ODOO_TEST_CONF_FILE)";
-        odoo_extra_options="$odoo_extra_options -d $test_db_name";
     fi
+    echo "$test_db_name";
+}
 
-    # Remove log file if it is present before test, otherwise
-    # it will be appended, wich could lead to incorrect test results
-    if [ -e $test_log_file ]; then
-        rm $test_log_file;
-    fi
 
-    # Reinitialize base module, to find new addons
-    if [ ! -z $reinit_base ]; then
-        echo -e "${BLUEC}Reinitializing base module...${NC}";
-        run_server_impl -c $ODOO_TEST_CONF_FILE $odoo_extra_options --init=base --log-level=warn \
-            --stop-after-init --no-xmlrpc;
-    fi
-
-    # Test modules
-    for module in $modules; do
+# Run tests for set of addons
+# test_run_tests_for_modules <test_db_name> <log_file> <module_1> [module2] ...
+function test_run_tests_for_modules {
+    local test_db_name=$1;
+    local test_log_file=$2;
+    shift; shift;
+    for module in $@; do
         echo -e "${BLUEC}Testing module $module...${NC}";
-        if [ -z $no_tee ]; then
-            # TODO: applying tee in this way makes output not colored
-            test_module_impl $module $odoo_extra_options | tee -a $test_log_file;
-        else
-            test_module_impl $module $odoo_extra_options;
-        fi
+        test_module_impl $module --database $test_db_name \
+            2>&1 | tee -a $test_log_file;
     done
+}
 
 
-    # Drop test db created
-    if [ ! -z $create_test_db ]; then
-        echo  -e "${BLUEC}Droping test database: $test_db_name${NC}";
-        odoo_db_drop $test_db_name $ODOO_TEST_CONF_FILE
-    fi
-
+# Parse log file
+# test_parse_log_file <test_db_name> <log_file> [fail_on_warn]
+function test_parse_log_file {
+    local test_db_name=$1;
+    local test_log_file=$2;
+    local fail_on_warn=$3;
     # remove color codes from log file
     sed -ri "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g" $test_log_file;
 
@@ -237,19 +145,130 @@ function test_module {
     fi
 
     # If Test is ok but there are warnings and set option 'fail-on-warn', fail this test
-    if [ $res -eq 0 ] && [ $warnings -ne 0 ] && [ ! -z $fail_on_warn ]; then
+    if [ $res -eq 0 ] && [ $warnings -ne 0 ] && [ $fail_on_warn -eq 1 ]; then
         res=1
     fi
 
-    if [ $res -eq 0 ]; then
+    return $res
+    
+}
+
+
+# Run tests
+# test_run_tests <create_test_db 1|0> <reinit_base 1|0> <fail_on_warn 1|0> <modules>
+function test_run_tests {
+    local create_test_db=$1;
+    local reinit_base=$2;
+    local fail_on_warn=$3;
+    shift; shift; shift;
+
+    # Create new test database if required
+    local test_db_name="$(test_get_or_create_db $create_test_db)";
+    local test_log_file="${LOG_DIR:-.}/odoo.test.db.$test_db_name.log";
+
+    # Remove log file if it is present before test, otherwise
+    # it will be appended, wich could lead to incorrect test results
+    if [ -e $test_log_file ]; then
+        rm $test_log_file;
+    fi
+
+    # Reinitialize base module, to find new addons
+    if [ $reinit_base -eq 1 ]; then
+        echo -e "${BLUEC}Reinitializing base module...${NC}";
+        test_run_server -d $test_db_name --init=base --log-level=warn;
+    fi
+
+    test_run_tests_for_modules $test_db_name $test_log_file $@;
+
+    # Drop created test db
+    if [ ! -z $create_test_db ]; then
+        echo  -e "${BLUEC}Droping test database: $test_db_name${NC}";
+        odoo_db_drop $test_db_name $ODOO_TEST_CONF_FILE
+    fi
+
+    if test_parse_log_file $test_db_name $test_log_file $fail_on_warn; then
         echo -e "TEST RESULT: ${GREENC}OK${NC}";
     else
         echo -e "TEST RESULT: ${REDC}FAIL${NC}";
+        return 1;
+    fi
+}
+
+# test_module [--create-test-db] -m <module_name>
+# test_module [--tmp-dirs] [--create-test-db] -m <module name> -m <module name>
+function test_module {
+    local create_test_db=0;
+    local reinit_base=0;
+    local fail_on_warn=0;
+    local modules="";
+    local usage="
+    Usage 
+
+        $SCRIPT_NAME test_module [options] [-m <module_name>] [-m <module name>] ...
+
+    Options:
+        --create-test-db    - Creates temporary database to run tests in
+        --reinit-base       - this option adds 'base' module to init list. this is way to reload module list in existing database
+        --fail-on-warn      - if this option passed, then tests will fail even on warnings
+        --tmp-dirs          - use temporary dirs for test related downloads and addons
+        --no-rm-tmp-dirs    - not remove temporary directories that was created for this test
+    ";
+
+    # Parse command line options and run commands
+    if [[ $# -lt 1 ]]; then
+        echo "No options/commands supplied $#: $@";
+        echo "$usage";
+        exit 0;
     fi
 
-    if [ ! -z $remove_log_file ]; then
-        rm $test_log_file;
+    while [[ $# -gt 0 ]]
+    do
+        key="$1";
+        case $key in
+            -h|--help|help)
+                echo "$usage";
+                exit 0;
+            ;;
+            --create-test-db)
+                local create_test_db=1;
+            ;;
+            --reinit-base)
+                local reinit_base=1;
+            ;;
+            --fail-on-warn)
+                local fail_on_warn=1;
+            ;;
+            -m|--module)
+                modules="$modules $2";  # add module to module list
+                shift;
+            ;;
+            --tmp-dirs)
+                local tmp_dirs=1
+            ;;
+            --no-rm-tmp-dirs)
+                local not_remove_tmp_dirs=1;
+            ;;
+            *)
+                echo "Unknown option: $key";
+                exit 1;
+            ;;
+        esac;
+        shift;
+    done;
+
+    if [ ! -z $tmp_dirs ]; then
+        create_tmp_dirs;
     fi
+
+    # Run tests
+    if test_run_tests ${create_test_db:-0} ${reinit_base:-0} \
+            ${fail_on_warn:-0} $modules;
+    then
+        local res=$?;
+    else
+        local res=$?
+    fi
+    # ---------
 
     if [ ! -z $tmp_dirs ] && [ -z $not_remove_tmp_dirs ]; then
         remove_tmp_dirs;

--- a/lib/tr.bash
+++ b/lib/tr.bash
@@ -38,6 +38,7 @@ function tr_parse_addons {
     if [ "$1" == "all" ]; then
         addons_get_installed_addons $db;
     else
+        local installed_addons="$(addons_get_installed_addons $db)"
         local addons=;
         while [[ $# -gt 0 ]]; do  # while there at least one argumet left
             if [[ "$1" =~ ^--dir=(.*)$ ]]; then
@@ -47,7 +48,8 @@ function tr_parse_addons {
             fi
             shift;
         done
-        echo "$(join_by , $addons)";
+        local todo_addons="$(join_by , $addons)";
+        echo $(execv python -c "\"print ','.join(set('$todo_addons'.split(',')) & set('$installed_addons'.split(',')))\"");
     fi;
 }
 
@@ -81,7 +83,7 @@ function tr_import_export_internal {
             continue
         fi
 
-        # dow the work
+        # do the work
         odoo_py -d $db -l $lang $extra_opt --i18n-$cmd=$i18n_file --modules=$addon;
     done
 }

--- a/tests/ci.bash
+++ b/tests/ci.bash
@@ -27,5 +27,6 @@ if [ ! -z $CI_RUN ]; then
         echo "";
         
     fi
+    sudo apt-get install python-all-dev;
     sudo pip install --upgrade pip pytz;
 fi

--- a/tests/test.bash
+++ b/tests/test.bash
@@ -232,22 +232,22 @@ odoo-helper server --stop-after-init;  # test that it runs
 odoo-helper status
 
 
-echo -e "${YELLOWC}
-==========================
-Install and check Odoo 10.0 
-==========================
-${NC}"
+#echo -e "${YELLOWC}
+#==========================
+#Install and check Odoo 10.0 
+#==========================
+#${NC}"
 
-# got back to test root and install odoo version 9.0
-cd ../;
-odoo-helper install sys-deps -y 10.0;
-odoo-install --install-dir odoo-10.0 --odoo-version 10.0 \
-    --conf-opt-xmlrpc_port 8369 --conf-opt-xmlrpcs_port 8371 --conf-opt-longpolling_port 8372
+## got back to test root and install odoo version 9.0
+#cd ../;
+#odoo-helper install sys-deps -y 10.0;
+#odoo-install --install-dir odoo-10.0 --odoo-version 10.0 \
+    #--conf-opt-xmlrpc_port 8369 --conf-opt-xmlrpcs_port 8371 --conf-opt-longpolling_port 8372
 
-cd odoo-10.0;
-odoo-helper server --stop-after-init;  # test that it runs
+#cd odoo-10.0;
+#odoo-helper server --stop-after-init;  # test that it runs
 
-# Show project status
-odoo-helper status
+## Show project status
+#odoo-helper status
 
 

--- a/tests/test.bash
+++ b/tests/test.bash
@@ -232,22 +232,22 @@ odoo-helper server --stop-after-init;  # test that it runs
 odoo-helper status
 
 
-#echo -e "${YELLOWC}
-#==========================
-#Install and check Odoo 10.0 
-#==========================
-#${NC}"
+echo -e "${YELLOWC}
+===========================
+Install and check Odoo 10.0
+===========================
+${NC}"
 
-## got back to test root and install odoo version 9.0
-#cd ../;
-#odoo-helper install sys-deps -y 10.0;
-#odoo-install --install-dir odoo-10.0 --odoo-version 10.0 \
-    #--conf-opt-xmlrpc_port 8369 --conf-opt-xmlrpcs_port 8371 --conf-opt-longpolling_port 8372
+# got back to test root and install odoo version 9.0
+cd ../;
+#odoo-helper install sys-deps -y 10.0;  # Ubuntu 12.04 have no all packages required
+odoo-install --install-dir odoo-10.0 --odoo-version 10.0 \
+    --conf-opt-xmlrpc_port 8369 --conf-opt-xmlrpcs_port 8371 --conf-opt-longpolling_port 8372
 
-#cd odoo-10.0;
-#odoo-helper server --stop-after-init;  # test that it runs
+cd odoo-10.0;
+odoo-helper server --stop-after-init;  # test that it runs
 
-## Show project status
-#odoo-helper status
+# Show project status
+odoo-helper status
 
 

--- a/tests/test.bash
+++ b/tests/test.bash
@@ -60,7 +60,7 @@ Test install of odoo version 7.0
 Also install dependencies and configure postgresql
 ==================================================
 ${NC}"
-odoo-install --install-dir odoo-7.0 --branch 7.0 --extra-utils --install-and-conf-postgres --install-sys-deps \
+odoo-install -i odoo-7.0 --branch 7.0 --postgres --sys-deps \
     --conf-opt-xmlrpc_port 8369 --conf-opt-xmlrpcs_port 8371
 cd odoo-7.0
 
@@ -162,7 +162,7 @@ Also install python package 'suds' in virtual env of this odoo instance
 ========================================================================
 ${NC}"
 # Let's install odoo of version 8.0 too here.
-odoo-install --install-dir odoo-8.0 --branch 8.0 --extra-utils\
+odoo-install --install-dir odoo-8.0 --branch 8.0 \
     --conf-opt-xmlrpc_port 8369 --conf-opt-xmlrpcs_port 8371 --conf-opt-longpolling_port 8372
 
 cd odoo-8.0
@@ -204,10 +204,28 @@ ${NC}"
 
 # got back to test root and install odoo version 9.0
 cd ../;
-odoo-install --install-dir odoo-9.0 --branch 9.0 --extra-utils\
+odoo-install --install-dir odoo-9.0 --branch 9.0 \
     --conf-opt-xmlrpc_port 8369 --conf-opt-xmlrpcs_port 8371 --conf-opt-longpolling_port 8372
 
 cd odoo-9.0;
+odoo-helper server --stop-after-init;  # test that it runs
+
+# Show project status
+odoo-helper status
+
+
+echo -e "${YELLOWC}
+==========================
+Install and check Odoo 10.0 
+==========================
+${NC}"
+
+# got back to test root and install odoo version 9.0
+cd ../;
+odoo-install --install-dir odoo-10.0 --branch 10.0 \
+    --conf-opt-xmlrpc_port 8369 --conf-opt-xmlrpcs_port 8371 --conf-opt-longpolling_port 8372
+
+cd odoo-10.0;
 odoo-helper server --stop-after-init;  # test that it runs
 
 # Show project status

--- a/tests/test.bash
+++ b/tests/test.bash
@@ -56,11 +56,27 @@ allow_colors;
 #
 echo -e "${YELLOWC}
 =================================================
+Install odoo-helper and odoo system prerequirements
+==================================================
+${NC}"
+
+odoo-helper install pre-requirements -y
+
+echo -e "${YELLOWC}
+=================================================
 Test install of odoo version 7.0
 Also install dependencies and configure postgresql
 ==================================================
 ${NC}"
-odoo-install -i odoo-7.0 --odoo-version 7.0 --postgres --sys-deps \
+
+# Install system dependencies for odoo version 7.0
+odoo-helper install sys-deps -y 7.0;
+
+# Install postgres and create there user with name='odoo' and password='odoo'
+odoo-helper install postgres odoo odoo
+
+# Install odoo 7.0
+odoo-install -i odoo-7.0 --odoo-version 7.0 \
     --conf-opt-xmlrpc_port 8369 --conf-opt-xmlrpcs_port 8371
 cd odoo-7.0
 

--- a/tests/test.bash
+++ b/tests/test.bash
@@ -60,7 +60,7 @@ Test install of odoo version 7.0
 Also install dependencies and configure postgresql
 ==================================================
 ${NC}"
-odoo-install -i odoo-7.0 --branch 7.0 --postgres --sys-deps \
+odoo-install -i odoo-7.0 --odoo-version 7.0 --postgres --sys-deps \
     --conf-opt-xmlrpc_port 8369 --conf-opt-xmlrpcs_port 8371
 cd odoo-7.0
 
@@ -162,7 +162,8 @@ Also install python package 'suds' in virtual env of this odoo instance
 ========================================================================
 ${NC}"
 # Let's install odoo of version 8.0 too here.
-odoo-install --install-dir odoo-8.0 --branch 8.0 \
+odoo-helper install sys-deps -y 8.0;
+odoo-install --install-dir odoo-8.0 --odoo-version 8.0 \
     --conf-opt-xmlrpc_port 8369 --conf-opt-xmlrpcs_port 8371 --conf-opt-longpolling_port 8372
 
 cd odoo-8.0
@@ -204,7 +205,8 @@ ${NC}"
 
 # got back to test root and install odoo version 9.0
 cd ../;
-odoo-install --install-dir odoo-9.0 --branch 9.0 \
+odoo-helper install sys-deps -y 9.0;
+odoo-install --install-dir odoo-9.0 --odoo-version 9.0 \
     --conf-opt-xmlrpc_port 8369 --conf-opt-xmlrpcs_port 8371 --conf-opt-longpolling_port 8372
 
 cd odoo-9.0;
@@ -222,7 +224,8 @@ ${NC}"
 
 # got back to test root and install odoo version 9.0
 cd ../;
-odoo-install --install-dir odoo-10.0 --branch 10.0 \
+odoo-helper install sys-deps -y 10.0;
+odoo-install --install-dir odoo-10.0 --odoo-version 10.0 \
     --conf-opt-xmlrpc_port 8369 --conf-opt-xmlrpcs_port 8371 --conf-opt-longpolling_port 8372
 
 cd odoo-10.0;


### PR DESCRIPTION
## Release 0.1.0

- Added ``odoo-helper addons pull_updates`` command
- Added basic support of Odoo 10
- Added ``odoo-helper --version`` command
- Refactored ``odoo-install`` script:
  - Always install python extra utils
  - Removed following options (primery goal of this, is to simplify ``odoo-install`` script):
    - ``--extra-utils``: extrautils are installed by default
    - ``--install-sys-deps``: use instead separate command: ``odoo-helper install``
    - ``--install-and-conf-postgres``: use instead separate command: ``odoo-helper install`` or ``odoo-helper postgres``
    - ``--use-system-packages``: seems to be not useful
    - ``--use-shallow-clone``: seems to be not useful
    - ``--use-unbuffer``: seems to be not useful
  - Added following options:
    - ``--odoo-version``: this option is useful in case of using custom
      repository and custom branch with name different then odoo's version branches
  - Fixed bug with ``--conf-opt-*`` and ``--test-conf-opt-*`` options
- Completely refactored ``odoo-helper test`` command
  - removed ``--reinit-base``
  - added ``--coverage`` options
  - Added subcommand ``odoo-helper test flake8``
  - Added subcommand ``odoo-helper test pylint``
- ``odoo-helper addons update-list`` command: ran for all databases if no db specified
- suppress git feedback in ``odoo-helper system update``
- improve system-wide install script: allow to choose odoo-helper branch or
  commit to install
- Added ability to run tests for directory.
  In this case odoo-helper script will automaticaly discover addons in
  that directory
- odoo-helper: added ``--no-colors`` option
- ``odoo-helper tr`` command improved:
  - ``import`` and ``load`` subcommands can be ran on all databases
  - ``import`` subcommand: added ability to search addons in directory
  - bugfix in ``tr import``: import translations only for installed addons
- Added ``addons test-installed`` command
  This allows to find databases where this addon is installed
- Bugfix: ``addons check_updates`` command: show repositories that caused errors when checking for updates
- ``addons status`` command now shows repository's remores
- ``odoo-helper fetch`` and ``odoo-helper link`` commands refactored:
  - Added recursion protection for both of therm, to avoid infinite recursion
  - ``odoo-helepr fetch`` filter-out uninstallable addons, on linking muti-addon repo
  - ``odoo-helper link`` now is recursive, thus it will look for odoo addons
    recursively in a specified directory and link them all.
- Added ``odoo-helper install`` command, which allows to install
  system dependencies for specific odoo version without installing odoo itself
- Added ``odoo-helper addons install --no-restart`` option
- Added ``odoo-helper addons update --no-restart`` option
- Added following shortcuts:
  - ``odoo-helper pip`` to run pip for current project
  - ``odoo-helper start`` for ``odoo-helper server start``
  - ``odoo-helper stop`` for ``odoo-helper server stop``
  - ``odoo-helper restart`` for ``odoo-helper server restart``
  - ``odoo-helper log`` for ``odoo-helper server log``
