### PR TITLE
Release 0.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 *.swn
 *.swo
 *.swm
+*.pyc
 /coverage/
 /venv/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 sudo: required
 dist: trusty
-language: bash
+language: ruby
 
 cache:
     pip: true
     apt: true
+
+rvm: 2.3
 
 env:
   global:
@@ -12,7 +14,7 @@ env:
     - ODOO_HELPER_ROOT=$TRAVIS_BUILD_DIR
 
 install:
-  - "rvm use 2.3"
+  - "sudo apt-get install -y -qq git python-all-dev libevent-dev expect-dev libxml2-dev"
   - "gem install bashcov coveralls"
   - "bash install-user.bash"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,9 @@ env:
 
 install:
   - "sudo apt-get install -y -qq python-all-dev libevent-dev"
-
+  - "echo easy_install --version"
+  - "sudo easy_install -U setuptools"
+  - "echo easy_install --version"
   - "rvm use 2.3"
   - "gem install bashcov coveralls"
   - "bash install-user.bash"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
     - ODOO_HELPER_ROOT=$TRAVIS_BUILD_DIR
 
 install:
-  - "sudo apt-get install -y -qq python-all-dev"
+  - "sudo apt-get install -y -qq python-all-dev libevent-dev"
 
   - "rvm use 2.3"
   - "gem install bashcov coveralls"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ env:
 
 install:
   - "sudo apt-get install -y -qq python-all-dev libevent-dev"
-  - "echo easy_install --version"
+  - "easy_install --version"
   - "sudo easy_install -U setuptools"
-  - "echo easy_install --version"
+  - "easy_install --version"
   - "rvm use 2.3"
   - "gem install bashcov coveralls"
   - "bash install-user.bash"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-#dist: trusty
+dist: trusty
 language: bash
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,6 @@ env:
     - ODOO_HELPER_ROOT=$TRAVIS_BUILD_DIR
 
 install:
-  - "sudo apt-get install -y -qq python-all-dev libevent-dev"
-  - "easy_install --version"
-  - "sudo easy_install -U setuptools"
-  - "easy_install --version"
   - "rvm use 2.3"
   - "gem install bashcov coveralls"
   - "bash install-user.bash"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - Added `odoo-helper db rename` command
 - Added `odoo-helper install reinstall-venv` option
 - `odoo-helper test`: Test only installable addons
+- `odoo-helper addons update-list` command support odoo 7.0
+- `odoo-helper addons test-installed` command support odoo 7.0
+
 
 ## Version 0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `odoo-helper addons update-list` command support odoo 7.0
 - `odoo-helper addons test-installed` command support odoo 7.0
 - `odoo-helper fetch`: added experimental support of Mercurial
+- `odoo-helper test --coverage-html` option added.
 
 
 ## Version 0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
   - `--demo` load demo data (default: not load)
   - `--lang <lang` choose language of database
   - `--help` display help message
+- `odoo-install --single-branch` option added. This allow to disable `single-branch` clone.
 
 
 ## Version 0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - Wrap pip with automaticaly set `PIP_FIND_LINKS` environment variable with [OCA Wheelhouse](https://wheelhouse.odoo-community.org/)
 - Added shortcut script `odoo-helper-restart` to restart server.
 - Added `odoo-helper db rename` command
+- Added `odoo-helper install reinstall-venv` option
 
 ## Version 0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `odoo-helper test`: Test only installable addons
 - `odoo-helper addons update-list` command support odoo 7.0
 - `odoo-helper addons test-installed` command support odoo 7.0
+- `odoo-helper fetch`: added experimental support of Mercurial
 
 
 ## Version 0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 - `odoo-helper addons test-installed` command support odoo 7.0
 - `odoo-helper fetch`: added experimental support of Mercurial
 - `odoo-helper test --coverage-html` option added.
+- `odoo-helper db create` new options added:
+  - `--demo` load demo data (default: not load)
+  - `--lang <lang` choose language of database
+  - `--help` display help message
 
 
 ## Version 0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added shortcut script `odoo-helper-restart` to restart server.
 - Added `odoo-helper db rename` command
 - Added `odoo-helper install reinstall-venv` option
+- `odoo-helper test`: Test only installable addons
 
 ## Version 0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Version 0.1.1
+
+- Support of Odoo 10.0
+- Support of [setuptools-odoo](https://pypi.python.org/pypi/setuptools-odoo)
+  - Automaticaly install in env
+  - Wrap pip with automaticaly set `PIP_FIND_LINKS` environment variable with [OCA Wheelhouse](https://wheelhouse.odoo-community.org/)
+- Added shortcut script `odoo-helper-restart` to restart server.
+- Added `odoo-helper db rename` command
+
 ## Version 0.1.0
 
 - Added ``odoo-helper addons pull_updates`` command

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Support of Odoo 10.0
 - Support of [setuptools-odoo](https://pypi.python.org/pypi/setuptools-odoo)
   - Automaticaly install in env
-  - Wrap pip with automaticaly set `PIP_FIND_LINKS` environment variable with [OCA Wheelhouse](https://wheelhouse.odoo-community.org/)
+  - Wrap pip with automaticaly set `PIP_EXTRA_INDEX_URL` environment variable with [OCA Wheelhouse](https://wheelhouse.odoo-community.org/)
 - Added shortcut script `odoo-helper-restart` to restart server.
 - Added `odoo-helper db rename` command
 - Added `odoo-helper install reinstall-venv` option
@@ -19,6 +19,8 @@
   - `--lang <lang` choose language of database
   - `--help` display help message
 - `odoo-install --single-branch` option added. This allow to disable `single-branch` clone.
+- Added `pychart` for install
+  `pychart` package is broken on pypi, so replace it with Python-Chart
 
 
 ## Version 0.1.0

--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ To install (system-wide) just do folowing:
 wget -O - https://raw.githubusercontent.com/katyukha/odoo-helper-scripts/master/install-system.bash | sudo bash -s
 ```
 
+or more explicit way:
+
+```bash
+wget -O /tmp/odoo-helper-install.bash;
+sudo bash /tmp/odoo-helper-install.bash;
+```
+
 After instalation You will have ```odoo-helper-scripts``` directory under ```/opt/``` directory.
 (also ```odoo-helper``` and ```odoo-install``` scripts will be linked to ```/usr/local/bin/``` dir).
 And ```/etc/odoo-helper.conf``` file will be generated with path to odoo-helper-scripts install dir.
@@ -42,6 +49,7 @@ wget -O - https://raw.githubusercontent.com/katyukha/odoo-helper-scripts/master/
 - Easy way to install from git repositories
     - Automatiacly resolve dependencies (oca_dependencies.txt, requirements.txt)
     - Specific format of dependencies: [odoo_requirements.txt](#syntax-of-odoo_requirementstxt)
+- Ability to fetch addons from Mercurial repositories
 - Easy mechanism to fetch addons from any git repo
 - Easy mechanism to fetch python dependency from PyPI or any vcs
 - Supports fetching dependencies for addons (incuding OCA dependencies and PIP requirements)
@@ -56,6 +64,9 @@ And after install you will have available folowing scripts in your path:
 
 Each script have ```-h``` or ```--help``` option which display most relevant information
 about script and all possible options and subcommands of script
+
+***Documentaion in this readme, or in other sources, may not be up to date!!!
+So use --help options, which is available for most of commands.***
 
 Look at [complete example](#complete-example)
 

--- a/bin/odoo-helper
+++ b/bin/odoo-helper
@@ -130,6 +130,12 @@ function show_project_status {
     ";
 }
 
+function odoo_helper_print_version {
+    echo "Version: $ODOO_HELPER_VERSION";
+    echo "Branch: $(git_get_branch_name $ODOO_HELPER_ROOT)";
+    echo "Commit: $(git_get_current_commit $ODOO_HELPER_ROOT)";
+}
+
 # function that parses commandline arguments and executes commands
 function odoo_helper_main {
     # Parse command line options and run commands
@@ -152,7 +158,7 @@ function odoo_helper_main {
                 exit 0;
             ;;
             --version)
-                echo "$ODOO_HELPER_VERSION";
+                odoo_helper_print_version;
                 exit 0;
             ;;
             --downloads-dir)

--- a/bin/odoo-helper
+++ b/bin/odoo-helper
@@ -81,7 +81,9 @@ function print_usage {
         start|stop|restart|log                   - shortcuts for server commands
         system [--help]                          - odoo-helper related functions
         exec <cmd> [args]                        - exec command in project environment. Useful if virtualenv is used
-        pip <pip arguments>                      - shortcut for *odoo-helper exec pip*
+        pip <pip arguments>                      - shortcut to run project-specific pip.
+                                                   It automaticaly configs pip to use OCA wheelhouse
+                                                   to install OCA addons easily.
         help | --help | -h                       - display this help message
         --version                                - display odoo-helper version and exit
     
@@ -284,7 +286,7 @@ function odoo_helper_main {
             pip)
                 shift;
                 load_project_conf;
-                execv pip "$@";
+                exec_pip "$@";
                 exit 0;
             ;;
             *)

--- a/bin/odoo-helper-restart
+++ b/bin/odoo-helper-restart
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Use odoo-helper --help for a documentation
+
+
+SCRIPT=$0;
+SCRIPT_NAME=`basename $SCRIPT`;
+F=`readlink -f $SCRIPT`;  # full script path;
+WORKDIR=`pwd`;
+
+# load basic conf
+if [ -f "/etc/odoo-helper.conf" ]; then
+    source "/etc/odoo-helper.conf";
+fi
+if [ -f "$HOME/odoo-helper.conf" ]; then
+    source "$HOME/odoo-helper.conf";
+fi
+# -----------
+
+set -e;  # Fail on errors
+
+
+if [ -z $ODOO_HELPER_LIB ]; then
+    echo "Odoo-helper-scripts seems not been installed correctly.";
+    echo "Reinstall it (see Readme on https://github.com/katyukha/odoo-helper-scripts/)";
+    exit 1;
+fi
+
+$ODOO_HELPER_BIN/odoo-helper server restart "$@";
+

--- a/bin/odoo-install
+++ b/bin/odoo-install
@@ -69,6 +69,10 @@ function print_usage {
          --download-archive on|off     - if on, then odoo will be downloaded as archive. it is faster
                                          if You want to clone Odoo repository set this option to 'off'
                                          Default: $DOWNLOAD_ARCHIVE
+         --single-branch               - if on, then odoo will clone only single branch,
+                                         which will speed-up install process.
+                                         This option is used only if --download-archive is 'off'
+                                         Default: $CLONE_SINGLE_BRANCH
          --db-host <host>              - database host to be used in settings. default: $DB_HOST
          --db-user <user>              - database user to be used in settings. default: $DB_USER
          --db-pass <password>          - database password to be used in settings. default: odoo
@@ -132,6 +136,10 @@ function parse_options {
             ;;
             --download-archive)
                 DOWNLOAD_ARCHIVE=$2;
+                shift;
+            ;;
+            --single-branch)
+                CLONE_SINGLE_BRANCH=$2;
                 shift;
             ;;
             --db-host)

--- a/lib/addons.bash
+++ b/lib/addons.bash
@@ -54,32 +54,27 @@ function addons_is_installable {
 }
 
 # Get list of installed addons
-# NOTE: Odoo 8.0+ required
 # addons_get_installed_addons <db> [conf_file]
 function addons_get_installed_addons {
     local db=$1;
     local conf_file=${2:-$ODOO_CONF_FILE};
 
-    local python_cmd="import lodoo; cl=lodoo.Client(['-c', '$conf_file']);";
-    python_cmd="$python_cmd odoo=cl._server; reg=odoo.registry('$db'); env=odoo.api.Environment(reg.cursor(), 1, {});";
-    python_cmd="$python_cmd installed_addons=env['ir.module.module'].search([('state', '=', 'installed')]);"
+    local python_cmd="import lodoo; cl=lodoo.LocalClient('$db', ['-c', '$conf_file']);";
+    python_cmd="$python_cmd installed_addons=cl['ir.module.module'].search([('state', '=', 'installed')]);"
     python_cmd="$python_cmd print ','.join(installed_addons.mapped('name'));"
 
     run_python_cmd "$python_cmd";
 }
 
 # Update list of addons visible in system (for single db)
-# NOTE: Odoo 8.0+ required
 # addons_update_module_list <db> [conf_file]
 function addons_update_module_list_db {
     local db=$1;
     local conf_file=${2:-$ODOO_CONF_FILE};
 
-    local python_cmd="import lodoo; cl=lodoo.Client(['-c', '$conf_file']);";
-    python_cmd="$python_cmd odoo=cl._server; reg=odoo.registry('$db');";
-    python_cmd="$python_cmd env=odoo.api.Environment(reg.cursor(), 1, {});";
-    python_cmd="$python_cmd res=env['ir.module.module'].update_list();";
-    python_cmd="$python_cmd env.cr.commit();";
+    local python_cmd="import lodoo; cl=lodoo.LocalClient('$db', ['-c', '$conf_file']);";
+    python_cmd="$python_cmd res=cl['ir.module.module'].update_list();";
+    python_cmd="$python_cmd cl.cursor.commit();";
     python_cmd="$python_cmd print('updated: %d\nadded: %d\n' % tuple(res));";
 
     run_python_cmd "$python_cmd";
@@ -87,7 +82,6 @@ function addons_update_module_list_db {
 
 
 # Update list of addons visible in system for db or all databases
-# NOTE: Odoo 8.0+ required
 # addons_update_module_list [db] [conf_file]
 function addons_update_module_list {
     local db=$1;

--- a/lib/addons.bash
+++ b/lib/addons.bash
@@ -18,6 +18,18 @@ ohelper_require 'fetch';
 set -e; # fail on errors
 
 
+# Get odoo addon manifest file
+# addons_get_manifest_file <addon path>
+function addons_get_manifest_file {
+    if [ -f "$1/__openerp__.py" ]; then
+        echo "$1/__openerp__.py";
+    elif [ -f "$1/__manifest__.py" ]; then
+        echo "$1/__manifest__.py";
+    else
+        return 2;
+    fi
+}
+
 # Echo path to addon specified by name
 # addons_get_addon_path <addon>
 function addons_get_addon_path {
@@ -39,18 +51,21 @@ function addons_get_addon_path {
 # addons_is_installable <addon_path>
 function addons_is_installable {
     local addon_path=$1;
-    if [ -f "$1/__openerp__.py" ]; then
-        local manifest_file="$1/__openerp__.py";
-    elif [ -f "$1/__manifest__.py" ]; then
-        local manifest_file="$1/__manifest__.py";
-    else
-        return 2
-    fi
+    local manifest_file="$(addons_get_manifest_file $addon_path)";
     if python -c "exit(not eval(open('$manifest_file', 'rt').read()).get('installable', True))"; then
         return 0;
     else
         return 1;
     fi
+}
+
+# Get list of addon dependencies
+# addons_get_addon_dependencies <addon path>
+function addons_get_addon_dependencies {
+    local addon_path=$1;
+    local manifest_file="$(addons_get_manifest_file $addon_path)";
+
+    echo $(python -c "print ' '.join(eval(open('$manifest_file', 'rt').read()).get('depends', []))");
 }
 
 # Get list of installed addons

--- a/lib/addons.bash
+++ b/lib/addons.bash
@@ -60,12 +60,12 @@ function addons_get_installed_addons {
     local db=$1;
     local conf_file=${2:-$ODOO_CONF_FILE};
 
-    local python_cmd="import erppeek; cl=erppeek.Client(['-c', '$conf_file']);";
+    local python_cmd="import lodoo; cl=lodoo.Client(['-c', '$conf_file']);";
     python_cmd="$python_cmd odoo=cl._server; reg=odoo.registry('$db'); env=odoo.api.Environment(reg.cursor(), 1, {});";
     python_cmd="$python_cmd installed_addons=env['ir.module.module'].search([('state', '=', 'installed')]);"
     python_cmd="$python_cmd print ','.join(installed_addons.mapped('name'));"
 
-    execu python -c "\"$python_cmd\"";
+    run_python_cmd "$python_cmd";
 }
 
 # Update list of addons visible in system (for single db)
@@ -75,14 +75,14 @@ function addons_update_module_list_db {
     local db=$1;
     local conf_file=${2:-$ODOO_CONF_FILE};
 
-    local python_cmd="import erppeek; cl=erppeek.Client(['-c', '$conf_file']);";
+    local python_cmd="import lodoo; cl=lodoo.Client(['-c', '$conf_file']);";
     python_cmd="$python_cmd odoo=cl._server; reg=odoo.registry('$db');";
     python_cmd="$python_cmd env=odoo.api.Environment(reg.cursor(), 1, {});";
     python_cmd="$python_cmd res=env['ir.module.module'].update_list();";
     python_cmd="$python_cmd env.cr.commit();";
     python_cmd="$python_cmd print('updated: %d\nadded: %d\n' % tuple(res));";
 
-    execu python -c "\"$python_cmd\"";
+    run_python_cmd "$python_cmd";
 }
 
 
@@ -383,12 +383,12 @@ function addons_install_update {
 function addons_test_installed {
     local addons=$(join_by , $@);
     for db in $(odoo_db_list); do
-        local python_cmd="import erppeek; cl=erppeek.Client(['-c', '$ODOO_CONF_FILE']);";
+        local python_cmd="import lodoo; cl=lodoo.Client(['-c', '$ODOO_CONF_FILE']);";
         python_cmd="$python_cmd odoo=cl._server; reg=odoo.registry('$db'); env=odoo.api.Environment(reg.cursor(), 1, {});";
         python_cmd="$python_cmd is_installed=bool(env['ir.module.module'].search([('name', 'in', '$addons'.split(',')),('state', '=', 'installed')], count=1));"
         python_cmd="$python_cmd exit(not is_installed);"
 
-        if execu python -c "\"$python_cmd\"" >/dev/null 2>&1; then
+        if run_python_cmd "$python_cmd" >/dev/null 2>&1; then
             echo "$db";
         fi
     done

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -144,7 +144,7 @@ function create_dirs {
 function check_command {
     for test_cmd in $@; do
         if execv "command -v $test_cmd >/dev/null 2>&1"; then
-            echo "$test_cmd";
+            echo "command -v $test_cmd";
             return 0;
         fi;
     done

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -144,7 +144,7 @@ function create_dirs {
 function check_command {
     for test_cmd in $@; do
         if execv "command -v $test_cmd >/dev/null 2>&1"; then
-            echo "command -v $test_cmd";
+            echo "$(execv command -v $test_cmd)";
             return 0;
         fi;
     done

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -122,8 +122,8 @@ function execu {
 
 # Exec pip for this project. Also adds OCA wheelhouse to pip FINDLINKS list
 function exec_pip {
-    local new_findlinks="$PIP_FIND_LINKS https://wheelhouse.odoo-community.org/oca";
-    PIP_FIND_LINKS=$new_findlinks execv pip $@;
+    local extra_index="$PIP_EXTRA_INDEX_URL https://wheelhouse.odoo-community.org/oca-simple";
+    PIP_EXTRA_INDEX_URL=$extra_index execv pip $@;
 }
 
 

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -127,23 +127,7 @@ function execu {
 # exec_conf <conf> <cmd> <cmd args>
 function exec_conf {
     local conf=$1; shift;
-
-    local save_openerp_server=$OPENERP_SERVER;
-    local save_odoo_rc=$ODOO_RC;
-
-    export OPENERP_SERVER=$conf;
-    export ODOO_RC=$conf;  # for odoo 10.0+
-
-    if eval "$@"; then
-        local res=$?;
-    else
-        local res=$?;
-    fi
-
-    OPENERP_SERVER=$save_openerp_server;
-    ODOO_RC=$save_odoo_rc;
-
-    return $res;
+    OPENERP_SERVER="$conf" ODOO_RC="$conf" $@
 }
 
 # Exec pip for this project. Also adds OCA wheelhouse to pip FINDLINKS list

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -98,6 +98,7 @@ function execv {
     return $res
 
 }
+
 # simply pass all args to exec or unbuffer
 # depending on 'USE_UNBUFFER variable
 # Also take in account virtualenv
@@ -118,6 +119,31 @@ function execu {
     fi
 
     execv "$unbuffer_opt $@";
+}
+
+# Exec command with specified odoo config
+# This function automaticaly set's and unsets Odoo configuration variables
+#
+# exec_conf <conf> <cmd> <cmd args>
+function exec_conf {
+    local conf=$1; shift;
+
+    local save_openerp_server=$OPENERP_SERVER;
+    local save_odoo_rc=$ODOO_RC;
+
+    export OPENERP_SERVER=$conf;
+    export ODOO_RC=$conf;  # for odoo 10.0+
+
+    if eval "$@"; then
+        local res=$?;
+    else
+        local res=$?;
+    fi
+
+    OPENERP_SERVER=$save_openerp_server;
+    ODOO_RC=$save_odoo_rc;
+
+    return $res;
 }
 
 # Exec pip for this project. Also adds OCA wheelhouse to pip FINDLINKS list

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -120,6 +120,13 @@ function execu {
     execv "$unbuffer_opt $@";
 }
 
+# Exec pip for this project. Also adds OCA wheelhouse to pip FINDLINKS list
+function exec_pip {
+    local new_findlinks="$PIP_FIND_LINKS https://wheelhouse.odoo-community.org/oca";
+    PIP_FIND_LINKS=$new_findlinks execv pip $@;
+}
+
+
 
 # Simple function to create directories passed as arguments
 # create_dirs [dir1] [dir2] ... [dir_n]

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -8,7 +8,7 @@ declare -A ODOO_HELPER_IMPORTED_MODULES;
 ODOO_HELPER_IMPORTED_MODULES[common]=1
 
 # Define version number
-ODOO_HELPER_VERSION="0.1.0"
+ODOO_HELPER_VERSION="0.1.1"
 
 # if odoo-helper root conf is not loaded yet, try to load it
 # This is useful when this lib is used by external utils,

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -127,7 +127,7 @@ function execu {
 # exec_conf <conf> <cmd> <cmd args>
 function exec_conf {
     local conf=$1; shift;
-    OPENERP_SERVER="$conf" ODOO_RC="$conf" $@
+    OPENERP_SERVER="$conf" ODOO_RC="$conf" $@;
 }
 
 # Exec pip for this project. Also adds OCA wheelhouse to pip FINDLINKS list

--- a/lib/db.bash
+++ b/lib/db.bash
@@ -23,10 +23,10 @@ function odoo_db_create {
 
     echov "Creating odoo database $db_name using conf file $conf_file";
 
-    local python_cmd="import erppeek; cl=erppeek.Client(['-c', '$conf_file']);";
+    local python_cmd="import lodoo; cl=lodoo.Client(['-c', '$conf_file']);";
     python_cmd="$python_cmd cl.db.create_database(cl._server.tools.config['admin_passwd'], '$db_name', ${DB_DEMO:-True}, '${DB_LANG:-en_US}');"
 
-    execu python -c "\"$python_cmd\"";
+    run_python_cmd "$python_cmd";
     
     echo -e "${GREENC}Database $db_name created successfuly!${NC}";
 }
@@ -36,10 +36,10 @@ function odoo_db_drop {
     local db_name=$1;
     local conf_file=${2:-$ODOO_CONF_FILE};
 
-    local python_cmd="import erppeek; cl=erppeek.Client(['-c', '$conf_file']);";
+    local python_cmd="import lodoo; cl=lodoo.Client(['-c', '$conf_file']);";
     python_cmd="$python_cmd cl.db.drop(cl._server.tools.config['admin_passwd'], '$db_name');"
     
-    execu python -c "\"$python_cmd\"";
+    run_python_cmd "$python_cmd";
     
     echo -e "${GREENC}Database $db_name dropt successfuly!${NC}";
 }
@@ -48,10 +48,10 @@ function odoo_db_drop {
 function odoo_db_list {
     local conf_file=${1:-$ODOO_CONF_FILE};
 
-    local python_cmd="import erppeek; cl=erppeek.Client(['-c', '$conf_file']);";
+    local python_cmd="import lodoo; cl=lodoo.Client(['-c', '$conf_file']);";
     python_cmd="$python_cmd print '\n'.join(['%s'%d for d in cl.db.list()]);";
     
-    execu python -c "\"$python_cmd\"";
+    run_python_cmd "$python_cmd";
 }
 
 # odoo_db_exists <dbname> [odoo_conf_file]
@@ -59,10 +59,10 @@ function odoo_db_exists {
     local db_name=$1;
     local conf_file=${2:-$ODOO_CONF_FILE};
 
-    local python_cmd="import erppeek; cl=erppeek.Client(['-c', '$conf_file', '--logfile', '/dev/null']);";
+    local python_cmd="import lodoo; cl=lodoo.Client(['-c', '$conf_file', '--logfile', '/dev/null']);";
     python_cmd="$python_cmd exit(int(not(cl.db.db_exist('$db_name'))));";
     
-    if execu python -c "\"$python_cmd\""; then
+    if run_python_cmd "$python_cmd"; then
         echov "Database named '$db_name' exists!";
         return 0;
     else
@@ -90,11 +90,11 @@ function odoo_db_dump {
         fi
     fi
 
-    local python_cmd="import erppeek; cl=erppeek.Client(['-c', '$conf_file']);";
+    local python_cmd="import lodoo; cl=lodoo.Client(['-c', '$conf_file']);";
     python_cmd="$python_cmd dump=cl.db.dump(cl._server.tools.config['admin_passwd'], '$db_name' $format_opt).decode('base64');";
     python_cmd="$python_cmd open('$db_dump_file', 'wb').write(dump);";
     
-    if execu python -c "\"$python_cmd\""; then
+    if run_python_cmd "$python_cmd"; then
         echov "Database named '$db_name' dumped to '$db_dump_file'!";
         return 0;
     else
@@ -158,11 +158,11 @@ function odoo_db_restore {
     local db_dump_file=$2;
     local conf_file=${3:-$ODOO_CONF_FILE};
 
-    local python_cmd="import erppeek; cl=erppeek.Client(['-c', '$conf_file']);";
+    local python_cmd="import lodoo; cl=lodoo.Client(['-c', '$conf_file']);";
     python_cmd="$python_cmd res=cl.db.restore(cl._server.tools.config['admin_passwd'], '$db_name', open('$db_dump_file', 'rb').read().encode('base64'));";
     python_cmd="$python_cmd exit(0 if res else 1);";
     
-    if execu python -c "\"$python_cmd\""; then
+    if run_python_cmd "$python_cmd"; then
         echov "Database named '$db_name' restored from '$db_dump_file'!";
         return 0;
     else

--- a/lib/db.bash
+++ b/lib/db.bash
@@ -71,6 +71,22 @@ function odoo_db_exists {
     fi
 }
 
+# odoo_db_rename <old_name> <new_name> [odoo_conf_file]
+function odoo_db_rename {
+    local old_db_name=$1;
+    local new_db_name=$2;
+    local conf_file=${3:-$ODOO_CONF_FILE};
+
+    local python_cmd="import lodoo; cl=lodoo.Client(['-c', '$conf_file']);";
+    python_cmd="$python_cmd cl.db.rename(cl._server.tools.config['admin_passwd'], '$old_db_name', '$new_db_name');"
+    
+    if run_python_cmd "$python_cmd"; then
+        echo -e "${GREENC}Database $old_db_name renamed to $new_db_name successfuly!${NC}";
+    else
+        echo -e "${REDC}Cannot rename databse $old_db_name to $new_db_name!${NC}";
+    fi
+}
+
 # odoo_db_dump <dbname> <file-path> [format [odoo_conf_file]]
 # dump database to specified path
 function odoo_db_dump {
@@ -179,6 +195,7 @@ function odoo_db_command {
         $SCRIPT_NAME db exists <name> [odoo_conf_file]
         $SCRIPT_NAME db create <name> [odoo_conf_file]
         $SCRIPT_NAME db drop <name> [odoo_conf_file]
+        $SCRIPT_NAME db rename <old_name> <new_name> [odoo_conf_file]
         $SCRIPT_NAME db dump <name> <dump_file_path> [format [odoo_conf_file]]
         $SCRIPT_NAME db backup <name> [format [odoo_conf_file]]
         $SCRIPT_NAME db backup-all [format [odoo_conf_file]]
@@ -233,6 +250,11 @@ function odoo_db_command {
             exists)
                 shift;
                 odoo_db_exists "$@";
+                exit;
+            ;;
+            rename)
+                shift;
+                odoo_db_rename "$@";
                 exit;
             ;;
             -h|--help|help)

--- a/lib/db.bash
+++ b/lib/db.bash
@@ -48,7 +48,7 @@ function odoo_db_drop {
 function odoo_db_list {
     local conf_file=${1:-$ODOO_CONF_FILE};
 
-    local python_cmd="import lodoo; cl=lodoo.Client(['-c', '$conf_file']);";
+    local python_cmd="import lodoo; cl=lodoo.Client(['-c', '$conf_file', '--logfile', '/dev/null']);";
     python_cmd="$python_cmd print '\n'.join(['%s'%d for d in cl.db.list()]);";
     
     run_python_cmd "$python_cmd";

--- a/lib/fetch.bash
+++ b/lib/fetch.bash
@@ -180,10 +180,9 @@ function fetch_python_dep {
 function fetch_clone_repo_git {
     local repo_url=$1; shift;
     local repo_dest=$1; shift;
-    local repo_branch=$1; shift;
 
-    if [ ! -z $repo_branch ]; then
-        local repo_branch_opt="-b $repo_branch";
+    if [ ! -z $1 ]; then
+        local repo_branch_opt="-b $1";
     fi
 
     [ -z $VERBOSE ] && local git_clone_opt=" -q "

--- a/lib/git.bash
+++ b/lib/git.bash
@@ -27,6 +27,11 @@ function git_get_abs_repo_path {
     echo "$(cd $1 && git rev-parse --show-toplevel)";
 }
 
+# git_get_current_commit <path>
+function git_get_current_commit {
+    (cd $1 && git rev-parse --verify --short HEAD);
+}
+
 # git_get_branch_name [repo_path]
 function git_get_branch_name {
     local cdir=`pwd`;

--- a/lib/install.bash
+++ b/lib/install.bash
@@ -213,7 +213,7 @@ function install_python_prerequirements {
         flake8 flake8-colors setuptools-odoo cffi;
 
     if ! execv "python -c 'import pychart' >/dev/null 2>&1" ; then
-        execv pip install http://download.gna.org/pychart/PyChart-1.39.tar.gz;
+        execv pip install Python-Chart;
     fi
 
 }

--- a/lib/install.bash
+++ b/lib/install.bash
@@ -204,7 +204,7 @@ function install_python_prerequirements {
     execu easy_install --upgrade setuptools;
     execu pip install --upgrade pip erppeek \
         setproctitle python-slugify watchdog pylint pylint-odoo coverage \
-        flake8 flake8-colors;  
+        flake8 flake8-colors setuptools-odoo;
 
     if ! execu "python -c 'import pychart'"; then
         execu pip install http://download.gna.org/pychart/PyChart-1.39.tar.gz;

--- a/lib/install.bash
+++ b/lib/install.bash
@@ -19,7 +19,7 @@ function install_preconfigure_env {
     ODOO_REPO=${ODOO_REPO:-https://github.com/odoo/odoo.git};
     ODOO_VERSION=${ODOO_VERSION:-9.0};
     ODOO_BRANCH=${ODOO_BRANCH:-$ODOO_VERSION};
-    DOWNLOAD_ARCHIVE=${ODOO_DOWNLOAD_ARCHIVE:-on};
+    DOWNLOAD_ARCHIVE=${ODOO_DOWNLOAD_ARCHIVE:-${DOWNLOAD_ARCHIVE:-on}};
     DB_USER=${DB_USER:-${ODOO_DBUSER:-odoo}};
     DB_PASSWORD=${DB_PASSWORD:-${ODOO_DBPASSWORD:-odoo}};
     DB_HOST=${DB_HOST:-${ODOO_DBHOST:-localhost}};

--- a/lib/install.bash
+++ b/lib/install.bash
@@ -24,7 +24,6 @@ function install_preconfigure_env {
     DB_PASSWORD=${ODOO_DBPASSWORD:-odoo};
     DB_HOST=${ODOO_DBHOST:-localhost};
     DB_PORT=${ODOO_DBPORT:-5432};
-    VIRTUALENV_SYSTEM_SITE_PACKAGES=1;  # by default make virtualenv use system site packages
 }
 
 # create directory tree for project
@@ -331,11 +330,8 @@ function install_entry_point {
         $SCRIPT_NAME install sys-deps [-y] <odoo-version>  - install system dependencies for odoo version
         $SCRIPT_NAME install postgres [user] [password]    - install postgres.
                                                              and if user/password specified, create it
-        $SCRIPT_NAME install reinstall-venv [opts|--help]  - reinstall virtual environment (with python requirements and odoo)
+        $SCRIPT_NAME install reinstall-venv [opts|--help]  - reinstall virtual environment (with python requirements and odoo).
                                                              all options will be passed to virtualenv cmd directly
-                                                             by default, this option creates virtualenv withour system site packages,
-                                                             which is oposite to what odoo-install script do, but thus it allows to
-                                                             recreate virtualenv with any options you want.
         $SCRIPT_NAME install --help                        - show this help message
 
     ";

--- a/lib/install.bash
+++ b/lib/install.bash
@@ -301,7 +301,7 @@ function install_odoo_workaround_70 {
     execv pip install Pillow;
     cp $ODOO_PATH/setup.py $ODOO_PATH/setup.py.7.0.backup
     sed -i -r "s/PIL/Pillow/" $ODOO_PATH/setup.py;
-    #execv pip install http://effbot.org/media/downloads/PIL-1.1.7.tar.gz;
+    sed -i -r "s/pychart/Python-Chart/" $ODOO_PATH/setup.py;
 }
 
 function odoo_gevent_install_workaround_cleanup {
@@ -332,6 +332,9 @@ function odoo_run_setup_py {
                 # Pyparsing is used by new versions of setuptools, so it is bad idea to update it,
                 # especialy to versions lower than that used by setuptools
                 continue
+            elif [[ "$dependency_stripped" =~ pychart* ]]; then
+                # Pychart is not downloadable. Use Python-Chart package
+                echo "Python-Chart";
 			else
                 # Echo dependency line unchanged to rmp file
                 echo $dependency;

--- a/lib/install.bash
+++ b/lib/install.bash
@@ -20,6 +20,7 @@ function install_preconfigure_env {
     ODOO_VERSION=${ODOO_VERSION:-9.0};
     ODOO_BRANCH=${ODOO_BRANCH:-$ODOO_VERSION};
     DOWNLOAD_ARCHIVE=${ODOO_DOWNLOAD_ARCHIVE:-${DOWNLOAD_ARCHIVE:-on}};
+    CLONE_SINGLE_BRANCH=${CLONE_SINGLE_BRANCH:-on};
     DB_USER=${DB_USER:-${ODOO_DBUSER:-odoo}};
     DB_PASSWORD=${DB_PASSWORD:-${ODOO_DBPASSWORD:-odoo}};
     DB_HOST=${DB_HOST:-${ODOO_DBHOST:-localhost}};
@@ -46,13 +47,17 @@ function install_clone_odoo {
     local odoo_path=${1:-$ODOO_PATH};
     local odoo_branch=${2:-$ODOO_BRANCH};
     local odoo_repo=${3:-${ODOO_REPO:-https://github.com/odoo/odoo.git}};
+    local branch_opt=;
 
     if [ ! -z $odoo_branch ]; then
-        local branch_opt=" --branch $odoo_branch --single-branch";
+        branch_opt="$branch_opt --branch $odoo_branch";
+    fi
+
+    if [ "$CLONE_SINGLE_BRANCH" == "on" ]; then
+        branch_opt="$branch_opt --single-branch";
     fi
 
     git clone $branch_opt $odoo_repo $odoo_path;
-
 }
 
 # install_download_odoo [path [branch [repo]]]
@@ -175,8 +180,8 @@ function install_system_prerequirements {
     with_sudo apt-get update || true;
 
     echo "Installing system preprequirements...";
-    install_sys_deps_internal git wget python-setuptools perl g++ \
-        libpq-dev python-dev expect-dev libevent-dev libjpeg-dev \
+    install_sys_deps_internal git wget python-setuptools python-pip \
+        perl g++ libpq-dev python-dev expect-dev libevent-dev libjpeg-dev \
         libfreetype6-dev zlib1g-dev libxml2-dev libxslt-dev \
         libsasl2-dev libldap2-dev libssl-dev libffi-dev;
 
@@ -184,8 +189,7 @@ function install_system_prerequirements {
         echo "Cannot install wkhtmltopdf!!! Skipping...";
     fi
 
-    with_sudo easy_install pip;
-    with_sudo pip install --upgrade pip virtualenv cffi;
+    with_sudo pip install --upgrade virtualenv cffi;
 }
 
 

--- a/lib/install.bash
+++ b/lib/install.bash
@@ -91,8 +91,11 @@ function install_wkhtmltopdf {
     if ! check_command wkhtmltopdf > /dev/null; then
         local wkhtmltox_path=${DOWNLOADS_DIR:-/tmp}/wkhtmltox.deb;
         if [ ! -f $wkhtmltox_path ]; then
-            wget -q http://download.gna.org/wkhtmltopdf/0.12/0.12.2.1/wkhtmltox-0.12.2.1_linux-trusty-amd64.deb \
-                 -O $wkhtmltox_path
+            local system_arch=$(dpkg --print-architecture);
+            local release=$(lsb_release -sc);
+            local release=${release:-trusty};  # try to install trusty version
+            local download_link="https://downloads.wkhtmltopdf.org/0.12/0.12.2/wkhtmltox-0.12.2_linux-$release-$system_arch.deb"
+            wget -q $download_link -O $wkhtmltox_path;
         fi
         with_sudo dpkg --force-depends -i $wkhtmltox_path  # install ignoring dependencies
         with_sudo apt-get -f install $opt_apt_always_yes;   # fix broken packages
@@ -172,10 +175,6 @@ function install_and_configure_postgresql {
 
 # install_system_prerequirements
 function install_system_prerequirements {
-    if [ ! -z $ALWAYS_ANSWER_YES ]; then
-        local opt_apt_always_yes="-y";
-    fi
-
     echo "Updating package list..."
     with_sudo apt-get update || true;
 

--- a/lib/install.bash
+++ b/lib/install.bash
@@ -74,7 +74,7 @@ function install_download_odoo {
     if [[ $ODOO_REPO == "https://github.com"* ]]; then
         local repo=${odoo_repo%.git};
         local repo_base=$(basename $repo);
-        wget -O $odoo_archive $repo/archive/$ODOO_BRANCH.tar.gz;
+        wget -q -O $odoo_archive $repo/archive/$ODOO_BRANCH.tar.gz;
         tar -zxf $odoo_archive;
         mv ${repo_base}-${ODOO_BRANCH} $ODOO_PATH;
         rm $odoo_archive;
@@ -140,7 +140,7 @@ function install_sys_deps_for_odoo_version {
     local odoo_version=$1;
     local control_url="https://raw.githubusercontent.com/odoo/odoo/$odoo_version/debian/control";
     local tmp_control=$(mktemp);
-    wget $control_url -O $tmp_control;
+    wget -q $control_url -O $tmp_control;
     local sys_deps=$(install_parse_debian_control_file $tmp_control);
     install_sys_deps_internal $sys_deps;
     rm $tmp_control;

--- a/lib/install.bash
+++ b/lib/install.bash
@@ -123,7 +123,7 @@ function install_sys_deps_internal {
     if [ ! -z $ALWAYS_ANSWER_YES ]; then
         local opt_apt_always_yes="-y";
     fi
-    with_sudo apt-get install $opt_apt_always_yes "$@";
+    with_sudo apt-get install $opt_apt_always_yes --no-install-recommends "$@";
 }
 
 # install_parse_debian_control_file <control file>
@@ -335,6 +335,11 @@ function odoo_run_setup_py {
             elif [[ "$dependency_stripped" =~ pychart* ]]; then
                 # Pychart is not downloadable. Use Python-Chart package
                 echo "Python-Chart";
+            elif [[ "$dependency_stripped" =~ gevent* ]]; then
+                # Install last gevent, because old gevent versions (ex. 1.0.2)
+                # cause build errors.
+                # Instead last gevent (1.1.0+) have already prebuild wheels.
+                echo "gevent";
 			else
                 # Echo dependency line unchanged to rmp file
                 echo $dependency;

--- a/lib/postgres.bash
+++ b/lib/postgres.bash
@@ -33,6 +33,16 @@ function postgres_install_postgresql {
     sudo apt-get install -y postgresql;
 }
 
+
+# Test connection to local postgres instance
+function postgres_test_connection {
+    if ! sudo -u postgres -H psql -tA -c "SELECT 1;" >/dev/null 2>&1; then
+        echo -e "${REDC}ERROR:${NC} Cannot connect to local postgres DB!";
+        return 1;
+    fi
+    return 0;
+}
+
 # Check if postgresql user exists
 # NOTE: Requires SUDO
 #
@@ -55,6 +65,10 @@ function postgres_user_exists {
 function postgres_user_create {
     local user_name="$1";
     local user_password="$2";
+
+    if ! postgres_test_connection; then
+        return 1;
+    fi
 
     if ! postgres_user_exists $user_name; then
         sudo -u postgres -H psql -c "CREATE USER \"$user_name\" WITH CREATEDB PASSWORD '$user_password';"

--- a/lib/pylib/lodoo.py
+++ b/lib/pylib/lodoo.py
@@ -3,6 +3,7 @@
 """
 import os
 import atexit
+import pkg_resources
 
 
 import erppeek
@@ -18,9 +19,21 @@ def start_odoo_services(options=None, appname='odoo-helper'):
     Return the ``openerp`` package.
     """
     try:
-        import openerp as odoo
-    except:
+        # Odoo 10.0+
+
+        # this is required if there are addons installed via setuptools_odoo
+        pkg_resources.declare_namespace('odoo.addons')
+
+        # import odoo itself
         import odoo
+        import odoo.release  # to avoid 9.0 with odoo.py on path
+    except (ImportError, KeyError):
+        try:
+            # Odoo 9.0 and less versions
+            import openerp as odoo
+        except ImportError:
+            raise
+
     odoo._api_v7 = odoo.release.version_info < (8,)
     if not (odoo._api_v7 and odoo.osv.osv.service):
         os.putenv('TZ', 'UTC')

--- a/lib/pylib/lodoo.py
+++ b/lib/pylib/lodoo.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+""" Local odoo connection lib
+"""
+import os
+import atexit
+
+
+import erppeek
+
+# Based on code: https://github.com/tinyerp/erppeek
+# With PR applied: https://github.com/tinyerp/erppeek/pull/92
+def start_odoo_services(options=None, appname='odoo-helper'):
+    """Initialize the Odoo services.
+    Import the ``openerp`` package and load the Odoo services.
+    The argument `options` receives the command line arguments
+    for ``openerp``.  Example:
+      ``['-c', '/path/to/openerp-server.conf', '--without-demo', 'all']``.
+    Return the ``openerp`` package.
+    """
+    try:
+        import openerp as odoo
+    except:
+        import odoo
+    odoo._api_v7 = odoo.release.version_info < (8,)
+    if not (odoo._api_v7 and odoo.osv.osv.service):
+        os.putenv('TZ', 'UTC')
+        if appname is not None:
+            os.putenv('PGAPPNAME', appname)
+        odoo.tools.config.parse_config(options or [])
+        if odoo.release.version_info < (10,):
+            odoo._registry = odoo.modules.registry.RegistryManager
+        else:
+            odoo._registry = odoo.modules.registry.Registry
+        if odoo.release.version_info < (7,):
+            odoo.netsvc.init_logger()
+            odoo.osv.osv.start_object_proxy()
+            odoo.service.web_services.start_web_services()
+        elif odoo._api_v7:
+            odoo.service.start_internal()
+        else:   # Odoo v8
+            try:
+                odoo.api.Environment._local.environments = \
+                    odoo.api.Environments()
+            except AttributeError:
+                pass
+
+        def close_all():
+            for db in odoo._registry.registries.keys():
+                odoo.sql_db.close_db(db)
+        atexit.register(close_all)
+
+    return odoo
+
+
+# Monkeypatch erppeeks start services to be compatible with odoo 10.0
+erppeek.start_odoo_services = start_odoo_services
+
+# look same as erppeek
+from erppeek import *

--- a/lib/server.bash
+++ b/lib/server.bash
@@ -46,26 +46,17 @@ function server_get_pid {
     fi
 }
 
-# Internal function to run odoo server
-function run_server_impl {
+# server_run <arg1> .. <argN>
+# all arguments will be passed to odoo server
+function server_run {
     local SERVER=`get_server_script`;
     echo -e "${LBLUEC}Running server${NC}: $SERVER $@";
-    export OPENERP_SERVER=$ODOO_CONF_FILE;
-    export ODOO_RC=$ODOO_CONF_FILE;  # for odoo 10.0+
     if [ ! -z $SERVER_RUN_USER ]; then
         local sudo_opt="sudo -u $SERVER_RUN_USER -H -E";
         echov "Using server run opt: $sudo_opt";
     fi
 
-    execu "$sudo_opt $SERVER $@";
-    unset OPENERP_SERVER;
-    unset ODOO_RC;
-}
-
-# server_run <arg1> .. <argN>
-# all arguments will be passed to odoo server
-function server_run {
-    run_server_impl "$@";
+    exec_conf $ODOO_CONF_FILE execu "$sudo_opt $SERVER $@";
 }
 
 function server_start {
@@ -79,7 +70,7 @@ function server_start {
             exit 1;
         fi
 
-        run_server_impl --pidfile=$ODOO_PID_FILE "$@" &
+        server_run --pidfile=$ODOO_PID_FILE "$@" &
         local pid=$!;
         sleep 2;
         echo -e "${GREENC}Odoo started!${NC}";
@@ -264,8 +255,7 @@ function server {
 # odoo_py <args>
 function odoo_py {
     echov -e "${LBLUEC}Running odoo.py with arguments${NC}:  $@";
-    export OPENERP_SERVER=$ODOO_CONF_FILE;
-    execu odoo.py "$@";
-    unset OPENERP_SERVER;
+    local cmd=$(check_command odoo odoo-bin odoo.py);
+    exec_conf $ODOO_CONF_FILE execu cmd "$@";
 }
 

--- a/lib/test.bash
+++ b/lib/test.bash
@@ -65,21 +65,17 @@ function test_run_server {
     local with_coverage=$1; shift;
     local SERVER=`get_server_script`;
     echo -e "${LBLUEC}Running server [${YELLOWC}test${LBLUEC}]${NC}: $SERVER $@";
-    export OPENERP_SERVER=$ODOO_TEST_CONF_FILE;
 
     # enable test coverage
     if [ $with_coverage -eq 1 ]; then
         if [ -z $COVERAGE_INCLUDE ]; then
             local COVERAGE_INCLUDE="$(pwd)/*";
         fi
-        execu "coverage run --rcfile=$ODOO_HELPER_LIB/default_config/coverage.cfg \
-            --include='$COVERAGE_INCLUDE' $(execv command -v $SERVER) \
-            --stop-after-init $@";
+        exec_conf $ODOO_TEST_CONF_FILE execu "coverage run --rcfile=$ODOO_HELPER_LIB/default_config/coverage.cfg \
+            --include='$COVERAGE_INCLUDE' $SERVER --stop-after-init $@";
     else
-        execu "$SERVER --stop-after-init $@";
+        exec_conf $ODOO_TEST_CONF_FILE execu "$SERVER --stop-after-init $@";
     fi
-
-    unset OPENERP_SERVER;
 }
 
 # test_module_impl <with_coverage 0|1> <module> [extra_options]

--- a/lib/test.bash
+++ b/lib/test.bash
@@ -305,6 +305,7 @@ function test_module {
     local create_test_db=0;
     local fail_on_warn=0;
     local with_coverage=0;
+    local with_coverate_report_html=;
     local modules="";
     local directories="";
     local usage="
@@ -322,6 +323,7 @@ function test_module {
         --tmp-dirs          - use temporary dirs for test related downloads and addons
         --no-rm-tmp-dirs    - not remove temporary directories that was created for this test
         --coverage          - calculate code coverage (use python's *coverage* util)
+        --coverate-html     - automaticaly generate coverage html report
         -m|--module         - specify module to test
         -d|--directory      - specify directory with modules to test
     ";
@@ -349,6 +351,10 @@ function test_module {
             ;;
             --coverage)
                 with_coverage=1;
+            ;;
+            --coverage-html)
+                with_coverage=1;
+                with_coverate_report_html=1;
             ;;
             -m|--module)
                 modules="$modules $2";  # add module to module list
@@ -393,6 +399,10 @@ function test_module {
         local res=$?;
     else
         local res=$?
+    fi
+
+    if [ ! -z $with_coverate_report_html ]; then
+        execv coverage html;
     fi
     # ---------
 

--- a/lib/test.bash
+++ b/lib/test.bash
@@ -242,8 +242,10 @@ function test_find_modules_in_directories {
     #       addons will be also tested
     for directory in $@; do
         # skip non directories
-        for addon in $(addons_list_in_directory_by_name $directory); do
-            echo -n " $addon";
+        for addon_path in $(addons_list_in_directory $directory); do
+            if addons_is_installable $addon_path; then
+                echo -n " $(basename $addon_path)";
+            fi
         done
     done
 }

--- a/lib/test.bash
+++ b/lib/test.bash
@@ -89,12 +89,19 @@ function test_module_impl {
     local module=$2
     shift; shift;  # all next arguments will be passed to server
 
+    # Set correct log level (depends on odoo version)
+    if [ "$ODOO_VERSION" == "7.0" ]; then
+        local log_level='test';
+    else
+        local log_level='info';
+    fi
+
     set +e; # do not fail on errors
     # Install module
     test_run_server $with_coverage --init=$module --log-level=warn "$@";
     # Test module
     test_run_server $with_coverage --update=$module \
-        --log-level=test --test-enable "$@";
+        --log-level=$log_level --test-enable "$@";
     set -e; # Fail on any error
 }
 

--- a/lib/test.bash
+++ b/lib/test.bash
@@ -323,7 +323,7 @@ function test_module {
         --tmp-dirs          - use temporary dirs for test related downloads and addons
         --no-rm-tmp-dirs    - not remove temporary directories that was created for this test
         --coverage          - calculate code coverage (use python's *coverage* util)
-        --coverate-html     - automaticaly generate coverage html report
+        --coverage-html     - automaticaly generate coverage html report
         -m|--module         - specify module to test
         -d|--directory      - specify directory with modules to test
     ";

--- a/lib/tr.bash
+++ b/lib/tr.bash
@@ -84,7 +84,7 @@ function tr_import_export_internal {
         fi
 
         # do the work
-        odoo_py -d $db -l $lang $extra_opt --i18n-$cmd=$i18n_file --modules=$addon;
+        server_run -d $db -l $lang $extra_opt --i18n-$cmd=$i18n_file --modules=$addon;
     done
 }
 
@@ -121,7 +121,7 @@ function tr_load {
     local lang=$2;
 
     for idb in $(tr_parse_db_name $db); do
-        odoo_py -d $idb --load-language=$lang --stop-after-init;
+        server_run -d $idb --load-language=$lang --stop-after-init;
     done
 }
 

--- a/tests/ci.bash
+++ b/tests/ci.bash
@@ -27,6 +27,7 @@ if [ ! -z $CI_RUN ]; then
         echo "";
         
     fi
-    sudo apt-get install python-all-dev;
+    sudo apt-get -y install python-all-dev python-setuptools;
+    sudo easy_install -U setuptools pip;
     sudo pip install --upgrade pip pytz;
 fi

--- a/tests/ci.bash
+++ b/tests/ci.bash
@@ -27,7 +27,4 @@ if [ ! -z $CI_RUN ]; then
         echo "";
         
     fi
-    sudo apt-get -y install python-all-dev python-setuptools;
-    sudo easy_install -U setuptools pip;
-    sudo pip install --upgrade pip pytz;
 fi

--- a/tests/test.bash
+++ b/tests/test.bash
@@ -5,7 +5,7 @@
 SCRIPT=$0;
 SCRIPT_NAME=`basename $SCRIPT`;
 PROJECT_DIR=$(readlink -f "`dirname $SCRIPT`/..");
-TEST_TMP_DIR="$PROJECT_DIR/test-temp";
+TEST_TMP_DIR="${TEST_TMP_DIR:-$PROJECT_DIR/test-temp}";
 WORK_DIR=`pwd`;
 
 ERROR=;
@@ -54,6 +54,14 @@ allow_colors;
 # Start test
 # ==========
 #
+echo -e "${YELLOWC}
+===================================================
+Show odoo-helper-scripts version
+===================================================
+${NC}"
+odoo-helper --version;
+
+
 echo -e "${YELLOWC}
 ===================================================
 Install odoo-helper and odoo system prerequirements
@@ -199,7 +207,7 @@ echo "";
 # and install there for example addon 'project_sla' for 'project-service' Odoo Comutinty repository
 # Note  that odoo-helper script will automaticaly fetch branch named as server version in current install,
 # if another branch was not specified
-odoo-helper fetch --oca project-service -m project_sla
+odoo-helper fetch --oca project -m project_sla
 
 # and run tests for it
 odoo-helper test --create-test-db -m project_sla
@@ -272,6 +280,14 @@ echo "$(cat ./conf/odoo.conf)"
 echo "";
 
 odoo-helper server --stop-after-init;  # test that it runs
+
+# Also in odoo 10 it is possible to install addons via pip.
+# For example there are some OCA addons available for such install
+# Let's install for example mis-builder.
+# odoo-helper will automaticaly set correct pypi indexx or findlinks option
+# for pip, if it is called with this command.
+odoo-helper pip install odoo10-addon-mis-builder;
+
 
 # Show project status
 odoo-helper status

--- a/tests/test.bash
+++ b/tests/test.bash
@@ -63,119 +63,119 @@ ${NC}"
 odoo-helper install pre-requirements -y;
 odoo-helper install postgres;
 
-#echo -e "${YELLOWC}
-#=================================================
-#Test install of odoo version 7.0
-#Also install dependencies and configure postgresql
-#==================================================
-#${NC}"
+echo -e "${YELLOWC}
+=================================================
+Test install of odoo version 7.0
+Also install dependencies and configure postgresql
+==================================================
+${NC}"
 
-## Install system dependencies for odoo version 7.0
-#odoo-helper install sys-deps -y 7.0;
+# Install system dependencies for odoo version 7.0
+odoo-helper install sys-deps -y 7.0;
 
-## Install postgres and create there user with name='odoo' and password='odoo'
-#odoo-helper install postgres odoo7 odoo
+# Install postgres and create there user with name='odoo' and password='odoo'
+odoo-helper install postgres odoo7 odoo
 
-## Install odoo 7.0
-#odoo-install -i odoo-7.0 --odoo-version 7.0 \
-    #--conf-opt-xmlrpc_port 8369 --conf-opt-xmlrpcs_port 8371 \
-    #--db-user odoo7 --db-pass odoo
-#cd odoo-7.0
+# Install odoo 7.0
+odoo-install -i odoo-7.0 --odoo-version 7.0 \
+	--conf-opt-xmlrpc_port 8369 --conf-opt-xmlrpcs_port 8371 \
+	--db-user odoo7 --db-pass odoo
+cd odoo-7.0
 
-#echo "Generated odoo config:"
-#echo "$(cat ./conf/odoo.conf)"
-#echo "";
+echo "Generated odoo config:"
+echo "$(cat ./conf/odoo.conf)"
+echo "";
 
-## Now You will have odoo-7.0 installed in this directory.
-## Note, thant Odoo this odoo install uses virtual env (venv dir)
-## Also You will find there odoo-helper.conf config file
+# Now You will have odoo-7.0 installed in this directory.
+# Note, thant Odoo this odoo install uses virtual env (venv dir)
+# Also You will find there odoo-helper.conf config file
 
-#echo -e "${YELLOWC}
-#=================================
-#Test database management features
-#(create, list, and drop database)
-#=================================
-#${NC}"
+echo -e "${YELLOWC}
+=================================
+Test database management features
+(create, list, and drop database)
+=================================
+${NC}"
 
-## create test database if it does not exists yet
-#if ! odoo-helper db exists my-test-odoo-database; then
-    #odoo-helper db create my-test-odoo-database;
-#fi
+# create test database if it does not exists yet
+if ! odoo-helper db exists my-test-odoo-database; then
+	odoo-helper db create my-test-odoo-database;
+fi
 
-## list all odoo databases available for this odoo instance
-#odoo-helper db list
+# list all odoo databases available for this odoo instance
+odoo-helper db list
 
-## backup database
-#backup_file=$(odoo-helper db backup my-test-odoo-database);
+# backup database
+backup_file=$(odoo-helper db backup my-test-odoo-database);
 
-## drop test database if it exists
-#if odoo-helper db exists my-test-odoo-database; then
-    #odoo-helper db drop my-test-odoo-database;
-#fi
+# drop test database if it exists
+if odoo-helper db exists my-test-odoo-database; then
+	odoo-helper db drop my-test-odoo-database;
+fi
 
-## restore dropped database
-#odoo-helper db restore my-test-odoo-database $backup_file;
+# restore dropped database
+odoo-helper db restore my-test-odoo-database $backup_file;
 
-## ensure that database exists
-#odoo-helper db exists my-test-odoo-database
+# ensure that database exists
+odoo-helper db exists my-test-odoo-database
 
-## drop database egain
-#odoo-helper db drop my-test-odoo-database;
+# drop database egain
+odoo-helper db drop my-test-odoo-database;
 
-#echo -e "${YELLOWC}
-#=================================
-#Test 'odoo-helper server' command
-#=================================
-#${NC}"
-## So now You may run local odoo server (i.e openerp-server script).
-## Note that this command run's server in foreground.
-#odoo-helper server --stop-after-init  # This will automaticaly use config file: conf/odoo.conf
+echo -e "${YELLOWC}
+=================================
+Test 'odoo-helper server' command
+=================================
+${NC}"
+# So now You may run local odoo server (i.e openerp-server script).
+# Note that this command run's server in foreground.
+odoo-helper server --stop-after-init  # This will automaticaly use config file: conf/odoo.conf
 
-## Also you may run server in background using
-#odoo-helper server start
+# Also you may run server in background using
+odoo-helper server start
 
-## there are also few additional server related commands:
-#odoo-helper server status
-## odoo-helper server log    # note that this option runs less, so blocks for input
-#odoo-helper server restart
-#odoo-helper server stop
-#odoo-helper server status
+# there are also few additional server related commands:
+odoo-helper server status
+# odoo-helper server log    # note that this option runs less, so blocks for input
+odoo-helper server restart
+odoo-helper server stop
+odoo-helper server status
 
-## The one cool thing of odoo-helper script is that you may not remeber paths to odoo instalation,
-## and if you change directory to another inside your odoo project, everything will continue to work.
-#cd custom_addons
-#odoo-helper server status
-#odoo-helper server restart
-#odoo-helper server stop
-#odoo-helper server status
+# The one cool thing of odoo-helper script is that you may not remeber paths to odoo instalation,
+# and if you change directory to another inside your odoo project, everything will continue to work.
+cd custom_addons
+odoo-helper server status
+odoo-helper server restart
+odoo-helper server stop
+odoo-helper server status
 
 
-#echo -e "${YELLOWC}
-#============================================================
-#Fetch and test 'https://github.com/katyukha/base_tags' addon
-#============================================================
-#${NC}"
-## Let's install base_tags addon into this odoo installation
-#odoo-helper fetch --github katyukha/base_tags --branch master
+echo -e "${YELLOWC}
+============================================================
+Fetch and test 'https://github.com/katyukha/base_tags' addon
+============================================================
+${NC}"
+# Let's install base_tags addon into this odoo installation
+odoo-helper fetch --github katyukha/base_tags --branch master
 
-## Now look at custom_addons/ dir, there will be placed links to addons
-## from https://github.com/katyukha/base_tags repository
-## But repository itself is placed in downloads/ directory
-## By default no branch specified when You fetch module,
-## but there are -b or --branch option which can be used to specify which branch to fetch
+# Now look at custom_addons/ dir, there will be placed links to addons
+# from https://github.com/katyukha/base_tags repository
+# But repository itself is placed in downloads/ directory
+# By default no branch specified when You fetch module,
+# but there are -b or --branch option which can be used to specify which branch to fetch
 
-## Now let's run tests for these just installed modules
-#odoo-helper test --create-test-db -m base_tags -m product_tags
+# Now let's run tests for these just installed modules
+odoo-helper test --create-test-db -m base_tags -m product_tags
 
-## this will create test database (it will be dropt after test finishes) and 
-## run tests for modules 'base_tags' and 'product_tags'
+# this will create test database (it will be dropt after test finishes) and 
+# run tests for modules 'base_tags' and 'product_tags'
 
-## If You need color output from Odoo, you may use '--use-unbuffer' option,
-## but it depends on 'expect-dev' package
-#odoo-helper --use-unbuffer test --create-test-db -m base_tags -m product_tags
-## So... let's install one more odoo version
-## go back to directory containing our projects (that one, where odoo-7.0 project is placed)
-#cd ../../
+# If You need color output from Odoo, you may use '--use-unbuffer' option,
+# but it depends on 'expect-dev' package
+odoo-helper --use-unbuffer test --create-test-db -m base_tags -m product_tags
+# So... let's install one more odoo version
+# go back to directory containing our projects (that one, where odoo-7.0 project is placed)
+cd ../../
 
 echo -e "${YELLOWC}
 ========================================================================

--- a/tests/test.bash
+++ b/tests/test.bash
@@ -73,12 +73,17 @@ ${NC}"
 odoo-helper install sys-deps -y 7.0;
 
 # Install postgres and create there user with name='odoo' and password='odoo'
-odoo-helper install postgres odoo odoo
+odoo-helper install postgres odoo7 odoo
 
 # Install odoo 7.0
 odoo-install -i odoo-7.0 --odoo-version 7.0 \
-    --conf-opt-xmlrpc_port 8369 --conf-opt-xmlrpcs_port 8371
+    --conf-opt-xmlrpc_port 8369 --conf-opt-xmlrpcs_port 8371 \
+    --db-user odoo7 --db-pass odoo
 cd odoo-7.0
+
+echo "Generated odoo config:"
+echo "$(cat ./conf/odoo.conf)"
+echo "";
 
 # Now You will have odoo-7.0 installed in this directory.
 # Note, thant Odoo this odoo install uses virtual env (venv dir)
@@ -179,10 +184,16 @@ Also install python package 'suds' in virtual env of this odoo instance
 ${NC}"
 # Let's install odoo of version 8.0 too here.
 odoo-helper install sys-deps -y 8.0;
+odoo-helper postgres user-create odoo8 odoo
 odoo-install --install-dir odoo-8.0 --odoo-version 8.0 \
-    --conf-opt-xmlrpc_port 8369 --conf-opt-xmlrpcs_port 8371 --conf-opt-longpolling_port 8372
+    --conf-opt-xmlrpc_port 8369 --conf-opt-xmlrpcs_port 8371 --conf-opt-longpolling_port 8372 \
+    --db-user odoo8 --db-pass odoo
 
 cd odoo-8.0
+
+echo "Generated odoo config:"
+echo "$(cat ./conf/odoo.conf)"
+echo "";
 
 # and install there for example addon 'project_sla' for 'project-service' Odoo Comutinty repository
 # Note  that odoo-helper script will automaticaly fetch branch named as server version in current install,
@@ -222,10 +233,17 @@ ${NC}"
 # got back to test root and install odoo version 9.0
 cd ../;
 odoo-helper install sys-deps -y 9.0;
+odoo-helper postgres user-create odoo9 odoo;
 odoo-install --install-dir odoo-9.0 --odoo-version 9.0 \
-    --conf-opt-xmlrpc_port 8369 --conf-opt-xmlrpcs_port 8371 --conf-opt-longpolling_port 8372
+    --conf-opt-xmlrpc_port 8369 --conf-opt-xmlrpcs_port 8371 --conf-opt-longpolling_port 8372 \
+    --db-user odoo9 --db-pass odoo
 
 cd odoo-9.0;
+
+echo "Generated odoo config:"
+echo "$(cat ./conf/odoo.conf)"
+echo "";
+
 odoo-helper server --stop-after-init;  # test that it runs
 
 # Show project status
@@ -240,11 +258,18 @@ ${NC}"
 
 # got back to test root and install odoo version 9.0
 cd ../;
-#odoo-helper install sys-deps -y 10.0;  # Ubuntu 12.04 have no all packages required
+odoo-helper install sys-deps -y 10.0;  # Ubuntu 12.04 have no all packages required
+odoo-helper postgres user-create odoo10 odoo;
 odoo-install --install-dir odoo-10.0 --odoo-version 10.0 \
-    --conf-opt-xmlrpc_port 8369 --conf-opt-xmlrpcs_port 8371 --conf-opt-longpolling_port 8372
+    --conf-opt-xmlrpc_port 8369 --conf-opt-xmlrpcs_port 8371 --conf-opt-longpolling_port 8372 \
+    --db-user odoo10 --db-pass odoo
 
 cd odoo-10.0;
+
+echo "Generated odoo config:"
+echo "$(cat ./conf/odoo.conf)"
+echo "";
+
 odoo-helper server --stop-after-init;  # test that it runs
 
 # Show project status

--- a/tests/test.bash
+++ b/tests/test.bash
@@ -55,16 +55,16 @@ allow_colors;
 # ==========
 #
 echo -e "${YELLOWC}
-=================================================
+===================================================
 Install odoo-helper and odoo system prerequirements
-==================================================
+===================================================
 ${NC}"
 
 odoo-helper install pre-requirements -y;
 odoo-helper install postgres;
 
 echo -e "${YELLOWC}
-=================================================
+==================================================
 Test install of odoo version 7.0
 Also install dependencies and configure postgresql
 ==================================================

--- a/tests/test.bash
+++ b/tests/test.bash
@@ -60,7 +60,8 @@ Install odoo-helper and odoo system prerequirements
 ==================================================
 ${NC}"
 
-odoo-helper install pre-requirements -y
+odoo-helper install pre-requirements -y;
+odoo-helper install postgres;
 
 #echo -e "${YELLOWC}
 #=================================================

--- a/tests/test.bash
+++ b/tests/test.bash
@@ -62,119 +62,119 @@ ${NC}"
 
 odoo-helper install pre-requirements -y
 
-echo -e "${YELLOWC}
-=================================================
-Test install of odoo version 7.0
-Also install dependencies and configure postgresql
-==================================================
-${NC}"
+#echo -e "${YELLOWC}
+#=================================================
+#Test install of odoo version 7.0
+#Also install dependencies and configure postgresql
+#==================================================
+#${NC}"
 
-# Install system dependencies for odoo version 7.0
-odoo-helper install sys-deps -y 7.0;
+## Install system dependencies for odoo version 7.0
+#odoo-helper install sys-deps -y 7.0;
 
-# Install postgres and create there user with name='odoo' and password='odoo'
-odoo-helper install postgres odoo7 odoo
+## Install postgres and create there user with name='odoo' and password='odoo'
+#odoo-helper install postgres odoo7 odoo
 
-# Install odoo 7.0
-odoo-install -i odoo-7.0 --odoo-version 7.0 \
-    --conf-opt-xmlrpc_port 8369 --conf-opt-xmlrpcs_port 8371 \
-    --db-user odoo7 --db-pass odoo
-cd odoo-7.0
+## Install odoo 7.0
+#odoo-install -i odoo-7.0 --odoo-version 7.0 \
+    #--conf-opt-xmlrpc_port 8369 --conf-opt-xmlrpcs_port 8371 \
+    #--db-user odoo7 --db-pass odoo
+#cd odoo-7.0
 
-echo "Generated odoo config:"
-echo "$(cat ./conf/odoo.conf)"
-echo "";
+#echo "Generated odoo config:"
+#echo "$(cat ./conf/odoo.conf)"
+#echo "";
 
-# Now You will have odoo-7.0 installed in this directory.
-# Note, thant Odoo this odoo install uses virtual env (venv dir)
-# Also You will find there odoo-helper.conf config file
+## Now You will have odoo-7.0 installed in this directory.
+## Note, thant Odoo this odoo install uses virtual env (venv dir)
+## Also You will find there odoo-helper.conf config file
 
-echo -e "${YELLOWC}
-=================================
-Test database management features
-(create, list, and drop database)
-=================================
-${NC}"
+#echo -e "${YELLOWC}
+#=================================
+#Test database management features
+#(create, list, and drop database)
+#=================================
+#${NC}"
 
-# create test database if it does not exists yet
-if ! odoo-helper db exists my-test-odoo-database; then
-    odoo-helper db create my-test-odoo-database;
-fi
+## create test database if it does not exists yet
+#if ! odoo-helper db exists my-test-odoo-database; then
+    #odoo-helper db create my-test-odoo-database;
+#fi
 
-# list all odoo databases available for this odoo instance
-odoo-helper db list
+## list all odoo databases available for this odoo instance
+#odoo-helper db list
 
-# backup database
-backup_file=$(odoo-helper db backup my-test-odoo-database);
+## backup database
+#backup_file=$(odoo-helper db backup my-test-odoo-database);
 
-# drop test database if it exists
-if odoo-helper db exists my-test-odoo-database; then
-    odoo-helper db drop my-test-odoo-database;
-fi
+## drop test database if it exists
+#if odoo-helper db exists my-test-odoo-database; then
+    #odoo-helper db drop my-test-odoo-database;
+#fi
 
-# restore dropped database
-odoo-helper db restore my-test-odoo-database $backup_file;
+## restore dropped database
+#odoo-helper db restore my-test-odoo-database $backup_file;
 
-# ensure that database exists
-odoo-helper db exists my-test-odoo-database
+## ensure that database exists
+#odoo-helper db exists my-test-odoo-database
 
-# drop database egain
-odoo-helper db drop my-test-odoo-database;
+## drop database egain
+#odoo-helper db drop my-test-odoo-database;
 
-echo -e "${YELLOWC}
-=================================
-Test 'odoo-helper server' command
-=================================
-${NC}"
-# So now You may run local odoo server (i.e openerp-server script).
-# Note that this command run's server in foreground.
-odoo-helper server --stop-after-init  # This will automaticaly use config file: conf/odoo.conf
+#echo -e "${YELLOWC}
+#=================================
+#Test 'odoo-helper server' command
+#=================================
+#${NC}"
+## So now You may run local odoo server (i.e openerp-server script).
+## Note that this command run's server in foreground.
+#odoo-helper server --stop-after-init  # This will automaticaly use config file: conf/odoo.conf
 
-# Also you may run server in background using
-odoo-helper server start
+## Also you may run server in background using
+#odoo-helper server start
 
-# there are also few additional server related commands:
-odoo-helper server status
-# odoo-helper server log    # note that this option runs less, so blocks for input
-odoo-helper server restart
-odoo-helper server stop
-odoo-helper server status
+## there are also few additional server related commands:
+#odoo-helper server status
+## odoo-helper server log    # note that this option runs less, so blocks for input
+#odoo-helper server restart
+#odoo-helper server stop
+#odoo-helper server status
 
-# The one cool thing of odoo-helper script is that you may not remeber paths to odoo instalation,
-# and if you change directory to another inside your odoo project, everything will continue to work.
-cd custom_addons
-odoo-helper server status
-odoo-helper server restart
-odoo-helper server stop
-odoo-helper server status
+## The one cool thing of odoo-helper script is that you may not remeber paths to odoo instalation,
+## and if you change directory to another inside your odoo project, everything will continue to work.
+#cd custom_addons
+#odoo-helper server status
+#odoo-helper server restart
+#odoo-helper server stop
+#odoo-helper server status
 
 
-echo -e "${YELLOWC}
-============================================================
-Fetch and test 'https://github.com/katyukha/base_tags' addon
-============================================================
-${NC}"
-# Let's install base_tags addon into this odoo installation
-odoo-helper fetch --github katyukha/base_tags --branch master
+#echo -e "${YELLOWC}
+#============================================================
+#Fetch and test 'https://github.com/katyukha/base_tags' addon
+#============================================================
+#${NC}"
+## Let's install base_tags addon into this odoo installation
+#odoo-helper fetch --github katyukha/base_tags --branch master
 
-# Now look at custom_addons/ dir, there will be placed links to addons
-# from https://github.com/katyukha/base_tags repository
-# But repository itself is placed in downloads/ directory
-# By default no branch specified when You fetch module,
-# but there are -b or --branch option which can be used to specify which branch to fetch
+## Now look at custom_addons/ dir, there will be placed links to addons
+## from https://github.com/katyukha/base_tags repository
+## But repository itself is placed in downloads/ directory
+## By default no branch specified when You fetch module,
+## but there are -b or --branch option which can be used to specify which branch to fetch
 
-# Now let's run tests for these just installed modules
-odoo-helper test --create-test-db -m base_tags -m product_tags
+## Now let's run tests for these just installed modules
+#odoo-helper test --create-test-db -m base_tags -m product_tags
 
-# this will create test database (it will be dropt after test finishes) and 
-# run tests for modules 'base_tags' and 'product_tags'
+## this will create test database (it will be dropt after test finishes) and 
+## run tests for modules 'base_tags' and 'product_tags'
 
-# If You need color output from Odoo, you may use '--use-unbuffer' option,
-# but it depends on 'expect-dev' package
-odoo-helper --use-unbuffer test --create-test-db -m base_tags -m product_tags
-# So... let's install one more odoo version
-# go back to directory containing our projects (that one, where odoo-7.0 project is placed)
-cd ../../
+## If You need color output from Odoo, you may use '--use-unbuffer' option,
+## but it depends on 'expect-dev' package
+#odoo-helper --use-unbuffer test --create-test-db -m base_tags -m product_tags
+## So... let's install one more odoo version
+## go back to directory containing our projects (that one, where odoo-7.0 project is placed)
+#cd ../../
 
 echo -e "${YELLOWC}
 ========================================================================


### PR DESCRIPTION
- Support of Odoo 10.0
- Support of [setuptools-odoo](https://pypi.python.org/pypi/setuptools-odoo)
  - Automaticaly install in env
  - Wrap pip with automaticaly set `PIP_EXTRA_INDEX_URL` environment variable with [OCA Wheelhouse](https://wheelhouse.odoo-community.org/)
- Added shortcut script `odoo-helper-restart` to restart server.
- Added `odoo-helper db rename` command
- Added `odoo-helper install reinstall-venv` option
- `odoo-helper test`: Test only installable addons
- `odoo-helper addons update-list` command support odoo 7.0
- `odoo-helper addons test-installed` command support odoo 7.0
- `odoo-helper fetch`: added experimental support of Mercurial
- `odoo-helper test --coverage-html` option added.
- `odoo-helper db create` new options added:
  - `--demo` load demo data (default: not load)
  - `--lang <lang` choose language of database
  - `--help` display help message
- `odoo-install --single-branch` option added. This allow to disable `single-branch` clone.
- Added `pychart` for install
  `pychart` package is broken on pypi, so replace it with Python-Chart
