### PR TITLE
Release 0.1.3

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,1 +1,0 @@
-service_name: travis-ci

--- a/.simplecov
+++ b/.simplecov
@@ -1,7 +1,9 @@
 require 'simplecov'
-require 'coveralls'
+#require 'coveralls'
+require 'codecov'
 
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
   SimpleCov::Formatter::HTMLFormatter,
-  Coveralls::SimpleCov::Formatter
+#  Coveralls::SimpleCov::Formatter,
+  SimpleCov::Formatter::Codecov
 ]

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
   global:
     - CI_RUN=1
     - ODOO_HELPER_INSTALL_PATH=$TRAVIS_BUILD_DIR
+    - TEST_TMP_DIR=/tmp/odoo-helper-tests
 
 install:
   - "gem install bashcov:1.5.1 coveralls:0.8.13 codecov"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,17 +11,22 @@ rvm: 2.3
 env:
   global:
     - CI_RUN=1
-    - ODOO_HELPER_ROOT=$TRAVIS_BUILD_DIR
+    - ODOO_HELPER_INSTALL_PATH=$TRAVIS_BUILD_DIR
 
 install:
-  - "sudo apt-get install -y -qq git python-all-dev libevent-dev expect-dev libxml2-dev"
-  - "gem install bashcov coveralls"
+  #- "sudo apt-get install -y -qq git python-all-dev libevent-dev expect-dev libxml2-dev"
+  - "gem install bashcov:1.5.1 coveralls:0.8.13 codecov"
   - "bash install-user.bash"
 
 script:
   - "bashcov tests/test.bash"
+  #- "bashcov -r coveralls:Coveralls::SimpleCov::Formatter -r codecov:SimpleCov::Formatter::Codecov -- tests/test.bash"
 
 
 after_success:
+  - env
+  - coveralls version
+  - coveralls help
+  - coveralls
   - coveralls push
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,19 +14,8 @@ env:
     - ODOO_HELPER_INSTALL_PATH=$TRAVIS_BUILD_DIR
 
 install:
-  #- "sudo apt-get install -y -qq git python-all-dev libevent-dev expect-dev libxml2-dev"
   - "gem install bashcov:1.5.1 coveralls:0.8.13 codecov"
   - "bash install-user.bash"
 
 script:
   - "bashcov tests/test.bash"
-  #- "bashcov -r coveralls:Coveralls::SimpleCov::Formatter -r codecov:SimpleCov::Formatter::Codecov -- tests/test.bash"
-
-
-after_success:
-  - env
-  - coveralls version
-  - coveralls help
-  - coveralls
-  - coveralls push
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 - use [codecov](https://codecov.io) for code coverage
 - renamed command `odoo-helper print_config` to `odoo-helper print-config`
+- Removed old unused options
+  - `odoo-helper --addons-dir <addons_directory>`
+  - `odoo-helper --downloads-dir <downloads_directory>`
+  - `odoo-helper --virtual-env <virtual_env_dir>`
+  - `odoo-helper test --tmp-dirs`
+  - `odoo-helper test --no-rm-tmp-dirs`
 
 
 ## Version 0.1.2 (2017-10-04)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Version 0.1.3
+
+- use [codecov](https://codecov.io) for code coverage
+- renamed command `odoo-helper print_config` to `odoo-helper print-config`
+
+
 ## Version 0.1.2 (2017-10-04)
 
 - `odoo-install --python` option added. Now it is possible to install Odoo 11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added `odoo-helper test --coverage-skip-covered` option
 - Added `odoo-helper addons update-py-deps` command
 - Added aliase `odoo-helper-log`
+- Added `odoo-helper postgres psql` command
 - Removed old unused options
   - `odoo-helper --addons-dir <addons_directory>`
   - `odoo-helper --downloads-dir <downloads_directory>`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - renamed command `odoo-helper print_config` to `odoo-helper print-config`
 - Added `odoo-helper test --coverage-skip-covered` option
 - Added `odoo-helper addons update-py-deps` command
+- Added aliase `odoo-helper-log`
 - Removed old unused options
   - `odoo-helper --addons-dir <addons_directory>`
   - `odoo-helper --downloads-dir <downloads_directory>`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - use [codecov](https://codecov.io) for code coverage
 - renamed command `odoo-helper print_config` to `odoo-helper print-config`
+- Added `odoo-helper test --coverage-skip-covered` option
 - Removed old unused options
   - `odoo-helper --addons-dir <addons_directory>`
   - `odoo-helper --downloads-dir <downloads_directory>`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - use [codecov](https://codecov.io) for code coverage
 - renamed command `odoo-helper print_config` to `odoo-helper print-config`
 - Added `odoo-helper test --coverage-skip-covered` option
+- Added `odoo-helper addons update-py-deps` command
 - Removed old unused options
   - `odoo-helper --addons-dir <addons_directory>`
   - `odoo-helper --downloads-dir <downloads_directory>`

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Dev:
 ## Documentation note
 
 Documentaion in this readme, or in other sources, may not be up to date!!!
-So use *--help* options, which is available for most of commands.
+So use *--help* option, which is available for most of commands.
 
 
 ## Usage note
@@ -75,7 +75,7 @@ wget -O - https://raw.githubusercontent.com/katyukha/odoo-helper-scripts/master/
 or more explicit way:
 
 ```bash
-wget -O /tmp/odoo-helper-install.bash;
+wget -O /tmp/odoo-helper-install.bash https://raw.githubusercontent.com/katyukha/odoo-helper-scripts/master/install-system.bash;
 sudo bash /tmp/odoo-helper-install.bash;
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 Master: 
 [![Build Status](https://travis-ci.org/katyukha/odoo-helper-scripts.svg?branch=master)](https://travis-ci.org/katyukha/odoo-helper-scripts)
-[![Coverage Status](https://coveralls.io/repos/github/katyukha/odoo-helper-scripts/badge.svg?branch=master)](https://coveralls.io/github/katyukha/odoo-helper-scripts?branch=master)
+[![Coverage Status](https://codecov.io/gh/katyukha/odoo-helper-scripts/branch/master/graph/badge.svg)](https://codecov.io/gh/katyukha/odoo-helper-scripts)
 
 Dev:
 [![Build Status](https://travis-ci.org/katyukha/odoo-helper-scripts.svg?branch=dev)](https://travis-ci.org/katyukha/odoo-helper-scripts)
-[![Coverage Status](https://coveralls.io/repos/github/katyukha/odoo-helper-scripts/badge.svg?branch=dev)](https://coveralls.io/github/katyukha/odoo-helper-scripts?branch=dev)
+[![Coverage Status](https://codecov.io/gh/katyukha/odoo-helper-scripts/branch/dev/graph/badge.svg)](https://codecov.io/gh/katyukha/odoo-helper-scripts/branch/dev)
 
 
 ## Features

--- a/bin/odoo-helper
+++ b/bin/odoo-helper
@@ -92,10 +92,6 @@ function print_usage {
         --version                                - display odoo-helper version and exit
     
     Global options:
-        --addons-dir <addons_directory>
-        --downloads-dir <downloads_directory>
-        --virtual-env <virtual_env_dir>       - optional, if specified, python dependencies
-                                                will be installed in that virtual env
         --use-copy                            - if set, then downloaded modules, repositories will
                                                 be copied instead of being symlinked
         --use-unbuffer                        - if set, then 'unbuffer' command from 'expect' package will be used
@@ -192,18 +188,6 @@ function odoo_helper_main {
             --version)
                 odoo_helper_print_version;
                 return 0;
-            ;;
-            --downloads-dir)
-                DOWNLOADS_DIR=$2;
-                shift;
-            ;;
-            --addons-dir)
-                ADDONS_DIR=$2;
-                shift;
-            ;;
-            --virtual-env)
-                VENV_DIR=$2;
-                shift;
             ;;
             --use-copy)
                 USE_COPY=1;

--- a/bin/odoo-helper
+++ b/bin/odoo-helper
@@ -78,7 +78,7 @@ function print_usage {
         update_odoo                              - update odoo source code
         odoo-py [args]                           - run project-specific odoo.py script
         scaffold [--help]                        - Scaffold repo, addon, model, etc
-        print_config                             - print current configuration
+        print-config                             - print current configuration
         status                                   - show project status
         start|stop|restart|log                   - shortcuts for server commands
         pylint                                   - shortcut for 'test pylint' command
@@ -178,7 +178,7 @@ function odoo_helper_main {
         config_load_project;
 
         print_usage;
-        exit 0;
+        return 0;
     fi
 
     while [[ $# -gt 0 ]]
@@ -187,11 +187,11 @@ function odoo_helper_main {
         case $key in
             -h|--help|help)
                 print_usage;
-                exit 0;
+                return 0;
             ;;
             --version)
                 odoo_helper_print_version;
-                exit 0;
+                return 0;
             ;;
             --downloads-dir)
                 DOWNLOADS_DIR=$2;
@@ -221,104 +221,104 @@ function odoo_helper_main {
                 shift;
                 config_load_project;
                 fetch_module "$@";
-                exit
+                return
             ;;
             generate_requirements)
                 shift;
                 config_load_project;
                 addons_generate_requirements "$@"
-                exit;
+                return;
             ;;
             update_odoo)
                 shift;
                 config_load_project;
                 odoo_update_sources "$@";
-                exit;
+                return;
             ;;
             link|link_module)
                 shift;
                 config_load_project;
                 link_command "$@"
-                exit;
+                return;
             ;;
             server)
                 shift;
                 config_load_project;
                 server "$@";
-                exit;
+                return;
             ;;
             addons)
                 shift;
                 config_load_project;
                 addons_command "$@";
-                exit;
+                return;
             ;;
             odoo-py)
                 shift;
                 config_load_project;
                 odoo_py "$@";
-                exit;
+                return;
             ;;
             scaffold)
                 shift;
                 config_load_project;
                 scaffold_parse_cmd "$@";
-                exit;
+                return;
             ;;
             test)
                 shift;
                 config_load_project;
                 test_module "$@";
-                exit;
+                return;
             ;;
             db)
                 shift;
                 config_load_project;
                 odoo_db_command "$@";
-                exit;
+                return;
             ;;
             tr)
                 shift;
                 config_load_project;
                 tr_main "$@";
-                exit;
+                return;
             ;;
             postgres)
                 shift;
                 postgres_command "$@";
-                exit;
+                return;
             ;;
             install)
                 shift;
                 install_entry_point "$@";
-                exit;
+                return;
             ;;
-            print_config)
+            print-config)
                 shift;
                 config_load_project;
                 config_print;
-                exit;
+                return;
             ;;
             status)
                 config_load_project;
                 show_project_status;
-                exit;
+                return;
             ;;
             system)
                 shift;
                 system_entry_point "$@";
-                exit;
+                return;
             ;;
             # Server shortcuts
             start|stop|restart|log)
                 config_load_project;
                 server "$@";
-                exit;
+                return;
             ;;
             pylint|flake8)
                 config_load_project;
                 test_module "$@";
-                exit;
+                return;
             ;;
             exec)
                 shift;
@@ -328,17 +328,17 @@ function odoo_helper_main {
                 else
                     execv "$@";
                 fi
-                exit 0;
+                return 0;
             ;;
             pip)
                 shift;
                 config_load_project;
                 exec_pip "$@";
-                exit 0;
+                return 0;
             ;;
             *)
                 echo "Unknown option global option /command $key";
-                exit 1;
+                return 1;
             ;;
         esac;
         shift;

--- a/bin/odoo-helper-log
+++ b/bin/odoo-helper-log
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Use odoo-helper --help for a documentation
+
+
+SCRIPT=$0;
+SCRIPT_NAME=`basename $SCRIPT`;
+F=`readlink -f $SCRIPT`;  # full script path;
+WORKDIR=`pwd`;
+
+# load basic conf
+if [ -f "/etc/odoo-helper.conf" ]; then
+    source "/etc/odoo-helper.conf";
+fi
+if [ -f "$HOME/odoo-helper.conf" ]; then
+    source "$HOME/odoo-helper.conf";
+fi
+# -----------
+
+set -e;  # Fail on errors
+
+
+if [ -z $ODOO_HELPER_LIB ]; then
+    echo "Odoo-helper-scripts seems not been installed correctly.";
+    echo "Reinstall it (see Readme on https://github.com/katyukha/odoo-helper-scripts/)";
+    exit 1;
+fi
+
+$ODOO_HELPER_BIN/odoo-helper log $@;
+
+

--- a/install-user.bash
+++ b/install-user.bash
@@ -24,7 +24,7 @@ if [ -f "$ODOO_HELPER_USER_CONF" ]; then
 fi
 
 # Configure paths
-INSTALL_PATH=${ODOO_HELPER_ROOT:-$HOME/odoo-helper-scripts};
+INSTALL_PATH=${ODOO_HELPER_INSTALL_PATH:-$HOME/odoo-helper-scripts};
 ODOO_HELPER_LIB=${ODOO_HELPER_LIB:-$INSTALL_PATH/lib};
 ODOO_HELPER_BIN=${ODOO_HELPER_BIN:-$INSTALL_PATH/bin};
 

--- a/lib/addons.bash
+++ b/lib/addons.bash
@@ -333,7 +333,7 @@ function addons_install_update_internal {
         server_run -d $db -u $todo_addons --stop-after-init --no-xmlrpc;
         return $?
     elif [ "$cmd" == "uninstall" ]; then
-        local addons_domain="[('name', 'in', '$todo_addons'.split(',')),('state', '=', 'installed')]";
+        local addons_domain="[('name', 'in', '$todo_addons'.split(',')),('state', 'in', ('installed', 'to upgrade', 'to remove'))]";
         local python_cmd="import lodoo; cl=lodoo.LocalClient('$db', ['-c', '$ODOO_CONF_FILE']);";
         python_cmd="$python_cmd cl.require_v8_api();";
         python_cmd="$python_cmd modules=cl['ir.module.module'].search($addons_domain);";

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -1,3 +1,6 @@
+# predefined filenames
+CONF_FILE_NAME="odoo-helper.conf";
+
 
 set -e; # fail on errors
 
@@ -14,12 +17,12 @@ ODOO_HELPER_IMPORTED_MODULES[common]=1
 #   oh_require 'server'
 #   ...
 
-if [ -z $ODOO_HELPER_ROOT ]; then
-    if [ -f "/etc/odoo-helper.conf" ]; then
-        source "/etc/odoo-helper.conf";
+if [ -z "$ODOO_HELPER_ROOT" ]; then
+    if [ -f "/etc/$CONF_FILE_NAME" ]; then
+        source "/etc/$CONF_FILE_NAME";
     fi
-    if [ -f "$HOME/odoo-helper.conf" ]; then
-        source "$HOME/odoo-helper.conf";
+    if [ -f "$HOME/$CONF_FILE_NAME" ]; then
+        source "$HOME/$CONF_FILE_NAME";
     fi
 
     if [ -z $ODOO_HELPER_ROOT ]; then
@@ -28,9 +31,6 @@ if [ -z $ODOO_HELPER_ROOT ]; then
         exit 1;
     fi
 fi
-
-# predefined filenames
-CONF_FILE_NAME="odoo-helper.conf";
 
 # Color related definitions
 function allow_colors {
@@ -60,7 +60,14 @@ allow_colors;
 # oh_get_lib_path <lib name>
 function oh_get_lib_path {
     local mod_name=$1;
-    echo "$ODOO_HELPER_LIB/$mod_name.bash";
+    local mod_path="$ODOO_HELPER_LIB/$mod_name.bash"
+    if [ -f $mod_path ]; then
+        echo "$mod_path";
+    else
+        >&2 echo -e "${REDC}ERROR${NC}: module ${YELLOWC}${mod_name}${NC} could not been loaded." \
+                    "Looking for module in ${BLUEC}${ODOO_HELPER_LIB}${NC}";
+        return 1;
+    fi
 }
 
 # Simplify import controll
@@ -75,192 +82,4 @@ function ohelper_require {
 
 # Import version info
 ohelper_require "version";
-
-
-# Simple function to exec command in virtual environment if required
-function execv {
-    if [ ! -z $VENV_DIR ]; then
-        source $VENV_DIR/bin/activate;
-    fi
-
-    # Eval command and save result
-    if eval "$@"; then
-        local res=$?;
-    else
-        local res=$?;
-    fi
-
-    # deactivate virtual environment
-    if [ ! -z $VENV_DIR ] && [ ! -z $VIRTUAL_ENV ]; then
-        deactivate;
-    fi
-
-    return $res
-
-}
-
-# simply pass all args to exec or unbuffer
-# depending on 'USE_UNBUFFER variable
-# Also take in account virtualenv
-function execu {
-    # Check unbuffer option
-    if [ ! -z $USE_UNBUFFER ] && ! command -v unbuffer >/dev/null 2>&1; then
-        echo -e "${REDC}Command 'unbuffer' not found. Install it to use --use-unbuffer option";
-        echo -e "It could be installed by installing package *expect-dev*";
-        echo -e "Using standard behavior${NC}";
-        USE_UNBUFFER=;
-    fi
-
-    # Decide wether to use unbuffer or not
-    if [ ! -z $USE_UNBUFFER ]; then
-        local unbuffer_opt="unbuffer";
-    else
-        local unbuffer_opt="";
-    fi
-
-    execv "$unbuffer_opt $@";
-}
-
-# Exec command with specified odoo config
-# This function automaticaly set's and unsets Odoo configuration variables
-#
-# exec_conf <conf> <cmd> <cmd args>
-function exec_conf {
-    local conf=$1; shift;
-    OPENERP_SERVER="$conf" ODOO_RC="$conf" $@;
-}
-
-# Exec pip for this project. Also adds OCA wheelhouse to pip FINDLINKS list
-function exec_pip {
-    local extra_index="$PIP_EXTRA_INDEX_URL https://wheelhouse.odoo-community.org/oca-simple";
-    PIP_EXTRA_INDEX_URL=$extra_index execv pip $@;
-}
-
-
-
-# Simple function to create directories passed as arguments
-# create_dirs [dir1] [dir2] ... [dir_n]
-function create_dirs {
-    for dir in $@; do
-        if [ ! -d $dir ]; then
-            mkdir -p "$dir";
-        fi
-    done;
-}
-
-
-# Simple function to check if at least one command exists.
-# Returns first existing command
-function check_command {
-    for test_cmd in $@; do
-        if execv "command -v $test_cmd >/dev/null 2>&1"; then
-            echo "$(execv command -v $test_cmd)";
-            return 0;
-        fi;
-    done
-    return 1;
-}
-
-
-# echov $@
-# echo if verbose is on
-function echov {
-    if [ ! -z "$VERBOSE" ]; then
-        echoe $@;
-    fi
-}
-
-# echoe $@
-# echo to STDERR
-function echoe {
-    >&2 echo $@;
-}
-
-# check if process is running
-# is_process_running <pid>
-function is_process_running {
-    kill -0 $1 >/dev/null 2>&1;
-    return $?;
-}
-
-# random_string [length]
-# default length = 8
-function random_string {
-    < /dev/urandom tr -dc A-Za-z0-9 | head -c${1:-8};
-}
-
-# search_file_up <start path> <file name>
-# Try to find file in start_path, if found, print path, if not found,
-# then try to find it in parent directory recursively
-function search_file_up {
-    local path=$1;
-    while [[ "$path" != "/" ]];
-    do
-        if [ -e "$path/$2" ]; then
-            echo "$path/$2";
-            return 0;
-        fi
-        path=`dirname $path`;
-    done
-}
-
-# Try to find file in one of directories specified
-# search_file_in <file_name> <dir1> [dir2] [dir3] ...
-function search_file_in {
-    local file_name=$1;
-    shift;  # skip first argument
-
-    while [[ $# -gt 0 ]]  # while there at least one argumet left
-    do
-        local path=$(readlink -f $1);
-        if [ -e "$path/$file_name" ]; then
-            echo "$path/$file_name";
-            return 0;
-        fi
-        shift
-    done
-}
-
-# is_odoo_module <module_path>
-function is_odoo_module {
-    if [ ! -d $1 ]; then
-       return 1;
-    elif [ -f "$1/__manifest__.py" ]; then
-        # Odoo 10.0+
-        return 0;
-    elif [ -f "$1/__openerp__.py" ]; then
-        # Odoo 6.0 - 9.0
-        return 0;
-    else
-        return 1;
-    fi
-}
-
-
-# with_sudo <args>
-# Run command with sudo if required
-function with_sudo {
-    if [[ $UID != 0 ]]; then
-        sudo $@;
-    else
-        $@
-    fi
-}
-
-# Join arguments useing arg $1 as separator
-# join_by , a "b c" d -> a,b c,d
-# origin: http://stackoverflow.com/questions/1527049/bash-join-elements-of-an-array#answer-17841619
-function join_by {
-    local IFS="$1";
-    shift;
-    echo "$*";
-}
-
-# Run python code
-#
-# run_python_cmd <code>
-function run_python_cmd {
-    local python_cmd="import sys; sys.path.append('$ODOO_HELPER_LIB/pylib');";
-    python_cmd="$python_cmd $1";
-    execu python -c "\"$python_cmd\"";
-}
+ohelper_require "utils";

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -60,12 +60,12 @@ allow_colors;
 # oh_get_lib_path <lib name>
 function oh_get_lib_path {
     local mod_name=$1;
-    local mod_path="$ODOO_HELPER_LIB/$mod_name.bash"
+    local mod_path=$ODOO_HELPER_LIB/$mod_name.bash;
     if [ -f $mod_path ]; then
         echo "$mod_path";
     else
         >&2 echo -e "${REDC}ERROR${NC}: module ${YELLOWC}${mod_name}${NC} could not been loaded." \
-                    "Looking for module in ${BLUEC}${ODOO_HELPER_LIB}${NC}";
+                    "Looking for module in '${BLUEC}${ODOO_HELPER_LIB}${NC}'";
         return 1;
     fi
 }
@@ -80,6 +80,6 @@ function ohelper_require {
     fi
 }
 
-# Import version info
+# Import version info and utils
 ohelper_require "version";
 ohelper_require "utils";

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -7,10 +7,6 @@ ODOO_HELPER_COMMON_IMPORTED=1;
 declare -A ODOO_HELPER_IMPORTED_MODULES;
 ODOO_HELPER_IMPORTED_MODULES[common]=1
 
-# Define version number
-ODOO_HELPER_VERSION="0.1.2";
-ODOO_HELPER_CONFIG_VERSION="1";
-
 # if odoo-helper root conf is not loaded yet, try to load it
 # This is useful when this lib is used by external utils,
 # making possible to write things like:
@@ -76,6 +72,9 @@ function ohelper_require {
         source $(oh_get_lib_path $mod_name);
     fi
 }
+
+# Import version info
+ohelper_require "version";
 
 
 # Simple function to exec command in virtual environment if required

--- a/lib/install.bash
+++ b/lib/install.bash
@@ -152,6 +152,10 @@ function install_parse_debian_control_file {
             '${python3:Depends}')
                 continue
             ;;
+            \$\{*)
+                # Skip dependencies stared with ${
+                continue
+            ;;
             python-pypdf|python-pypdf2|python3-pypdf2)
                 # Will be installed by pip from requirements.txt
                 continue

--- a/lib/server.bash
+++ b/lib/server.bash
@@ -148,7 +148,11 @@ function server_restart {
 # Update odoo sources
 function server_auto_update {
     # Stop odoo server
-    server_stop;
+    if [ $(server_get_pid) -gt 0 ]; then
+        echoe -e "${BLUEC}Stopping server...${NC}";
+        server_stop;
+        local need_start=1;
+    fi
 
     # Do database backup
     odoo_db_backup_all zip;
@@ -156,11 +160,14 @@ function server_auto_update {
     # Update odoo sources
     odoo_update_sources;
 
-    echoe -e "${LBLUEC}update databases...${NC}";
+    echoe -e "${BLUEC}update databases...${NC}";
     addons_install_update "update" all;
 
-    # Start server
-    server_start;
+    # Start server again if it was stopped
+    if [ ! -z $need_start ]; then
+        echoe -e "${BLUEC}Starting server...${NC}";
+        server_start;
+    fi
 }
 
 # Print ps aux output for odoo-related processes

--- a/lib/system.bash
+++ b/lib/system.bash
@@ -67,16 +67,16 @@ function system_entry_point {
             update)
                 shift;
                 system_update_odoo_helper_scripts "$@";
-                exit 0;
+                exit;
             ;;
             lib-path)
                 shift;
                 oh_get_lib_path "$@"
-                exit 0;
+                exit;
             ;;
             -h|--help|help)
                 echo "$usage";
-                exit 0;
+                exit;
             ;;
             *)
                 echo "Unknown option / command $key";

--- a/lib/test.bash
+++ b/lib/test.bash
@@ -277,6 +277,7 @@ function test_module {
     local with_coverage=0;
     local with_coverage_report_html=;
     local with_coverage_report=;
+    local with_coverage_skip_covered=;
     local modules="";
     local directories="";
     local usage="
@@ -289,14 +290,15 @@ function test_module {
         $SCRIPT_NAME test pylint [--disable=E111,E222,...] <addon path> [addon path]
 
     Options:
-        --create-test-db    - Creates temporary database to run tests in
-        --recreate-db       - Recreate test database if it already exists
-        --fail-on-warn      - if this option passed, then tests will fail even on warnings
-        --coverage          - calculate code coverage (use python's *coverage* util)
-        --coverage-html     - automaticaly generate coverage html report
-        --coverage-report   - print coverage report
-        -m|--module         - specify module to test
-        -d|--directory      - specify directory with modules to test
+        --create-test-db         - Creates temporary database to run tests in
+        --recreate-db            - Recreate test database if it already exists
+        --fail-on-warn           - if this option passed, then tests will fail even on warnings
+        --coverage               - calculate code coverage (use python's *coverage* util)
+        --coverage-html          - automaticaly generate coverage html report
+        --coverage-report        - print coverage report
+        --coverage-skip-covered  - skip covered files in coverage report
+        -m|--module              - specify module to test
+        -d|--directory           - specify directory with modules to test
 
     Examples:
         $SCRIPT_NAME test -m my_cool_module        # test single addon
@@ -341,6 +343,9 @@ function test_module {
                 with_coverage=1;
                 with_coverage_report=1;
             ;;
+            --coverage-skip-covered)
+                with_coverage_skip_covered=1
+            ;;
             -m|--module)
                 modules="$modules $2";  # add module to module list
                 shift;
@@ -377,11 +382,19 @@ function test_module {
     fi
 
     if [ ! -z "$with_coverage_report_html" ]; then
-        execv coverage html;
+        if [ ! -z $with_coverage_skip_covered ]; then
+            execv coverage html --skip-covered;
+        else
+            execv coverage html;
+        fi
     fi
 
     if [ ! -z "$with_coverage_report" ]; then
-        execv coverage report;  # --skip-covered;
+        if [ ! -z $with_coverage_skip_covered ]; then
+            execv coverage report --skip-covered;
+        else
+            execv coverage report;
+        fi
     fi
     # ---------
 

--- a/lib/tr.bash
+++ b/lib/tr.bash
@@ -78,7 +78,7 @@ function tr_import_export_internal {
     local addons=;
     IFS=',' read -r -a addons <<< "$addons_data";
     for addon in ${addons[@]}; do
-        echoe -e "${BLUEC}Executing '$cmd' for (db='$db', lang='$lang').${NC} Processing addon: '$addon';";
+        echoe -e "${BLUEC}Executing ${YELLOWC}$cmd${BLUEC} for (db=${YELLOWC}$db${BLUEC}, lang=${YELLOWC}$lang${BLUEC}).${NC} Processing addon: ${YELLOWC}$addon${NC};";
         local addon_path=$(addons_get_addon_path $addon);
         local i18n_dir=$addon_path/i18n;
         local i18n_file=$i18n_dir/$file_name.po
@@ -310,7 +310,6 @@ function tr_regenerate {
     odoo_db_create --lang $lang --demo $tmp_db_name;
     
     # install addons
-    echo "addons_install_update install --no-restart -d $tmp_db_name $addons;"
     if addons_install_update "install" --no-restart -d $tmp_db_name $addons; then
         # export translations
         tr_export $tmp_db_name $lang $file_name $addons;

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -1,0 +1,203 @@
+# Odoo Helper Scripts: Utility functions
+
+if [ -z $ODOO_HELPER_LIB ]; then
+    echo "Odoo-helper-scripts seems not been installed correctly.";
+    echo "Reinstall it (see Readme on https://github.com/katyukha/odoo-helper-scripts/)";
+    exit 1;
+fi
+
+if [ -z $ODOO_HELPER_COMMON_IMPORTED ]; then
+    source $ODOO_HELPER_LIB/common.bash;
+fi
+
+
+set -e; # fail on errors
+
+# Simple function to exec command in virtual environment if required
+function execv {
+    if [ ! -z $VENV_DIR ]; then
+        source $VENV_DIR/bin/activate;
+    fi
+
+    # Eval command and save result
+    if eval "$@"; then
+        local res=$?;
+    else
+        local res=$?;
+    fi
+
+    # deactivate virtual environment
+    if [ ! -z $VENV_DIR ] && [ ! -z $VIRTUAL_ENV ]; then
+        deactivate;
+    fi
+
+    return $res
+
+}
+
+# simply pass all args to exec or unbuffer
+# depending on 'USE_UNBUFFER variable
+# Also take in account virtualenv
+function execu {
+    # Check unbuffer option
+    if [ ! -z $USE_UNBUFFER ] && ! command -v unbuffer >/dev/null 2>&1; then
+        echo -e "${REDC}Command 'unbuffer' not found. Install it to use --use-unbuffer option";
+        echo -e "It could be installed by installing package *expect-dev*";
+        echo -e "Using standard behavior${NC}";
+        USE_UNBUFFER=;
+    fi
+
+    # Decide wether to use unbuffer or not
+    if [ ! -z $USE_UNBUFFER ]; then
+        local unbuffer_opt="unbuffer";
+    else
+        local unbuffer_opt="";
+    fi
+
+    execv "$unbuffer_opt $@";
+}
+
+# Exec command with specified odoo config
+# This function automaticaly set's and unsets Odoo configuration variables
+#
+# exec_conf <conf> <cmd> <cmd args>
+function exec_conf {
+    local conf=$1; shift;
+    OPENERP_SERVER="$conf" ODOO_RC="$conf" $@;
+}
+
+# Exec pip for this project. Also adds OCA wheelhouse to pip FINDLINKS list
+function exec_pip {
+    local extra_index="$PIP_EXTRA_INDEX_URL https://wheelhouse.odoo-community.org/oca-simple";
+    PIP_EXTRA_INDEX_URL=$extra_index execv pip $@;
+}
+
+
+
+# Simple function to create directories passed as arguments
+# create_dirs [dir1] [dir2] ... [dir_n]
+function create_dirs {
+    for dir in $@; do
+        if [ ! -d $dir ]; then
+            mkdir -p "$dir";
+        fi
+    done;
+}
+
+
+# Simple function to check if at least one command exists.
+# Returns first existing command
+function check_command {
+    for test_cmd in $@; do
+        if execv "command -v $test_cmd >/dev/null 2>&1"; then
+            echo "$(execv command -v $test_cmd)";
+            return 0;
+        fi;
+    done
+    return 1;
+}
+
+
+# echov $@
+# echo if verbose is on
+function echov {
+    if [ ! -z "$VERBOSE" ]; then
+        echoe $@;
+    fi
+}
+
+# echoe $@
+# echo to STDERR
+function echoe {
+    >&2 echo $@;
+}
+
+# check if process is running
+# is_process_running <pid>
+function is_process_running {
+    kill -0 $1 >/dev/null 2>&1;
+    return $?;
+}
+
+# random_string [length]
+# default length = 8
+function random_string {
+    < /dev/urandom tr -dc A-Za-z0-9 | head -c${1:-8};
+}
+
+# search_file_up <start path> <file name>
+# Try to find file in start_path, if found, print path, if not found,
+# then try to find it in parent directory recursively
+function search_file_up {
+    local path=$1;
+    while [[ "$path" != "/" ]];
+    do
+        if [ -e "$path/$2" ]; then
+            echo "$path/$2";
+            return 0;
+        fi
+        path=`dirname $path`;
+    done
+}
+
+# Try to find file in one of directories specified
+# search_file_in <file_name> <dir1> [dir2] [dir3] ...
+function search_file_in {
+    local file_name=$1;
+    shift;  # skip first argument
+
+    while [[ $# -gt 0 ]]  # while there at least one argumet left
+    do
+        local path=$(readlink -f $1);
+        if [ -e "$path/$file_name" ]; then
+            echo "$path/$file_name";
+            return 0;
+        fi
+        shift
+    done
+}
+
+# is_odoo_module <module_path>
+function is_odoo_module {
+    if [ ! -d $1 ]; then
+       return 1;
+    elif [ -f "$1/__manifest__.py" ]; then
+        # Odoo 10.0+
+        return 0;
+    elif [ -f "$1/__openerp__.py" ]; then
+        # Odoo 6.0 - 9.0
+        return 0;
+    else
+        return 1;
+    fi
+}
+
+
+# with_sudo <args>
+# Run command with sudo if required
+function with_sudo {
+    if [[ $UID != 0 ]]; then
+        sudo $@;
+    else
+        $@
+    fi
+}
+
+# Join arguments useing arg $1 as separator
+# join_by , a "b c" d -> a,b c,d
+# origin: http://stackoverflow.com/questions/1527049/bash-join-elements-of-an-array#answer-17841619
+function join_by {
+    local IFS="$1";
+    shift;
+    echo "$*";
+}
+
+# Run python code
+#
+# run_python_cmd <code>
+function run_python_cmd {
+    local python_cmd="import sys; sys.path.append('$ODOO_HELPER_LIB/pylib');";
+    python_cmd="$python_cmd $1";
+    execu python -c "\"$python_cmd\"";
+}
+

--- a/lib/version.bash
+++ b/lib/version.bash
@@ -1,0 +1,5 @@
+# Define version number
+ODOO_HELPER_VERSION="0.1.3-dev";
+ODOO_HELPER_CONFIG_VERSION="1";
+
+

--- a/lib/version.bash
+++ b/lib/version.bash
@@ -1,3 +1,16 @@
+# Odoo Helper Scripts: Version
+
+if [ -z $ODOO_HELPER_LIB ]; then
+    echo "Odoo-helper-scripts seems not been installed correctly.";
+    echo "Reinstall it (see Readme on https://github.com/katyukha/odoo-helper-scripts/)";
+    exit 1;
+fi
+
+if [ -z $ODOO_HELPER_COMMON_IMPORTED ]; then
+    source $ODOO_HELPER_LIB/common.bash;
+fi
+
+
 # Define version number
 ODOO_HELPER_VERSION="0.1.3-dev";
 ODOO_HELPER_CONFIG_VERSION="1";

--- a/tests/ci.bash
+++ b/tests/ci.bash
@@ -27,6 +27,14 @@ if [ ! -z $CI_RUN ]; then
         echo "";
         
     fi
+    if [ -f /etc/odoo-helper.conf ]; then
+        echo "Content of odoo-helper global config";
+        echo $(cat /etc/odoo-helper.conf);
+    fi
+    if [ -f $HOME/odoo-helper.conf ]; then
+        echo "Content of odoo-helper global config";
+        echo $(cat $HOME/odoo-helper.conf);
+    fi
 else
     echo -e "\e[33m CI Environment not enabled \e[0m";
 

--- a/tests/ci.bash
+++ b/tests/ci.bash
@@ -32,7 +32,7 @@ if [ ! -z $CI_RUN ]; then
         echo $(cat /etc/odoo-helper.conf);
     fi
     if [ -f $HOME/odoo-helper.conf ]; then
-        echo "Content of odoo-helper global config";
+        echo "Content of odoo-helper home config";
         echo $(cat $HOME/odoo-helper.conf);
     fi
 else

--- a/tests/test.bash
+++ b/tests/test.bash
@@ -349,6 +349,9 @@ odoo-helper flake8 ./repositories/partner-contact/partner_firstname || true;
 # Show project status
 odoo-helper status
 
+# Print odoo helper configuration
+odoo-helper print-config
+
 
 echo -e "${YELLOWC}
 =================================

--- a/tests/test.bash
+++ b/tests/test.bash
@@ -228,6 +228,9 @@ odoo-helper fetch --github gisce/aeroo -n aeroo
 odoo-helper fetch -p git+https://github.com/jamotion/aeroolib#egg=aeroolib
 odoo-helper generate_requirements
 
+# Update install python requirements for addons (those that are in requirements.txt)
+odoo-helper addons update-py-deps
+
 echo -e "${YELLOWC}
 ==========================
 Install and check Odoo 9.0 

--- a/tests/test.bash
+++ b/tests/test.bash
@@ -199,10 +199,10 @@ odoo-helper test -m project_sla
 odoo-helper install py-tools
 
 # or run tests with test-coverage enabled
-odoo-helper test --coverage-report -m project_sla
+(cd ./repositories/project; odoo-helper test --coverage-report -m project_sla || true);
 
 # Also we may generate html coverage report too
-odoo-helper test --coverage-html -m project_sla
+(cd ./repositories/project; odoo-helper test --coverage-html -m project_sla || true);
 
 
 # also if you want to install python packages in current installation environment, you may use command:

--- a/tests/test.bash
+++ b/tests/test.bash
@@ -355,6 +355,15 @@ odoo-helper status
 # Print odoo helper configuration
 odoo-helper print-config
 
+# Update odoo source code
+odoo-helper server auto-update
+
+# Pull odoo addons update
+odoo-helper addons pull-updates
+
+# Update odoo base addon
+odoo-helper addons update base
+
 
 echo -e "${YELLOWC}
 =================================

--- a/tests/test.bash
+++ b/tests/test.bash
@@ -189,8 +189,20 @@ echo "";
 # if another branch was not specified
 odoo-helper fetch --oca project -m project_sla
 
+# create test database
+odoo-helper db create --demo odoo8-odoo-test
+
 # and run tests for it
-odoo-helper test --create-test-db -m project_sla
+odoo-helper test -m project_sla
+
+# Install py-tools to get coverage reports
+odoo-helper install py-tools
+
+# or run tests with test-coverage enabled
+odoo-helper test --coverage-report -m project_sla
+
+# Also we may generate html coverage report too
+odoo-helper test --coverage-html -m project_sla
 
 
 # also if you want to install python packages in current installation environment, you may use command:
@@ -328,6 +340,11 @@ odoo-helper pip install odoo10-addon-mis-builder;
 # regenerate Ukrainian translations for it
 odoo-helper fetch --oca partner-contact -m partner_firstname;
 odoo-helper tr regenerate --lang uk_UA --file uk_UA partner_firstname;
+
+# Check partner_first_name addon with pylint and flake8
+odoo-helper install py-tools
+odoo-helper pylint ./repositories/partner-contact/partner_firstname || true;
+odoo-helper flake8 ./repositories/partner-contact/partner_firstname || true;
 
 # Show project status
 odoo-helper status

--- a/tests/test.bash
+++ b/tests/test.bash
@@ -93,8 +93,8 @@ odoo-helper install postgres odoo7 odoo
 
 # Install odoo 7.0
 odoo-install -i odoo-7.0 --odoo-version 7.0 \
-	--conf-opt-xmlrpc_port 8369 --conf-opt-xmlrpcs_port 8371 \
-	--db-user odoo7 --db-pass odoo
+    --conf-opt-xmlrpc_port 8369 --conf-opt-xmlrpcs_port 8371 \
+    --db-user odoo7 --db-pass odoo
 cd odoo-7.0
 
 echo "Generated odoo config:"
@@ -267,7 +267,7 @@ ${NC}"
 
 # create test database if it does not exists yet
 if ! odoo-helper db exists my-test-odoo-database; then
-	odoo-helper db create my-test-odoo-database;
+    odoo-helper db create my-test-odoo-database;
 fi
 
 # list all odoo databases available for this odoo instance
@@ -278,7 +278,7 @@ backup_file=$(odoo-helper db backup my-test-odoo-database zip);
 
 # drop test database if it exists
 if odoo-helper db exists my-test-odoo-database; then
-	odoo-helper db drop my-test-odoo-database;
+    odoo-helper db drop my-test-odoo-database;
 fi
 
 # restore dropped database


### PR DESCRIPTION
- use [codecov](https://codecov.io) for code coverage
- renamed command `odoo-helper print_config` to `odoo-helper print-config`
- Added `odoo-helper test --coverage-skip-covered` option
- Added `odoo-helper addons update-py-deps` command
- Removed old unused options
  - `odoo-helper --addons-dir <addons_directory>`
  - `odoo-helper --downloads-dir <downloads_directory>`
  - `odoo-helper --virtual-env <virtual_env_dir>`
  - `odoo-helper test --tmp-dirs`
  - `odoo-helper test --no-rm-tmp-dirs`